### PR TITLE
[FEAT] LGTM Common Exceptions 처리 (#63)

### DIFF
--- a/app/src/main/java/com/lgtm/android/di/NavigatorModule.kt
+++ b/app/src/main/java/com/lgtm/android/di/NavigatorModule.kt
@@ -1,0 +1,18 @@
+package com.lgtm.android.di
+
+import com.lgtm.android.common_ui.navigator.FakeSignInNavigator
+import com.lgtm.android.navigator.SignInNavigator
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+
+@InstallIn(SingletonComponent::class)
+@Module
+interface NavigatorModule {
+    @Binds
+    fun bindsSignInNavigator(
+        signInNavigator: SignInNavigator
+    ): FakeSignInNavigator
+}

--- a/app/src/main/java/com/lgtm/android/di/NavigatorModule.kt
+++ b/app/src/main/java/com/lgtm/android/di/NavigatorModule.kt
@@ -15,4 +15,5 @@ interface NavigatorModule {
     fun bindsSignInNavigator(
         signInNavigator: SignInNavigator
     ): FakeSignInNavigator
+
 }

--- a/app/src/main/java/com/lgtm/android/navigator/SignInNavigator.kt
+++ b/app/src/main/java/com/lgtm/android/navigator/SignInNavigator.kt
@@ -4,10 +4,11 @@ import android.content.Context
 import android.content.Intent
 import com.lgtm.android.auth.ui.SignInActivity
 import com.lgtm.android.common_ui.navigator.FakeSignInNavigator
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class SignInNavigator @Inject constructor(
-    private val context: Context
+    @ApplicationContext private val context: Context
 ) : FakeSignInNavigator {
     override fun navigateToSignIn() {
         val intent = Intent(context, SignInActivity::class.java)

--- a/app/src/main/java/com/lgtm/android/navigator/SignInNavigator.kt
+++ b/app/src/main/java/com/lgtm/android/navigator/SignInNavigator.kt
@@ -1,0 +1,16 @@
+package com.lgtm.android.navigator
+
+import android.content.Context
+import android.content.Intent
+import com.lgtm.android.auth.ui.SignInActivity
+import com.lgtm.android.common_ui.navigator.FakeSignInNavigator
+import javax.inject.Inject
+
+class SignInNavigator @Inject constructor(
+    private val context: Context
+) : FakeSignInNavigator {
+    override fun navigateToSignIn() {
+        val intent = Intent(context, SignInActivity::class.java)
+        context.startActivity(intent)
+    }
+}

--- a/common-ui/src/main/java/com/lgtm/android/common_ui/base/BaseActivity.kt
+++ b/common-ui/src/main/java/com/lgtm/android/common_ui/base/BaseActivity.kt
@@ -1,20 +1,41 @@
 package com.lgtm.android.common_ui.base
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
+import com.lgtm.android.common_ui.navigator.FakeSignInNavigator
+import javax.inject.Inject
 
 abstract class BaseActivity<T : ViewDataBinding>(
     @LayoutRes private val layoutRes: Int
 ) : AppCompatActivity() {
     protected lateinit var binding: T
+    lateinit var viewModel: BaseViewModel
+
+    @Inject
+    lateinit var signInNavigator: FakeSignInNavigator
+    abstract fun initializeViewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, layoutRes)
         binding.lifecycleOwner = this
+    }
+
+    fun moveToSignInActivity() {
+        viewModel.moveToSignIn.observe(this) {
+            signInNavigator.navigateToSignIn()
+            finishAffinity()
+        }
+    }
+
+    fun makeToast() {
+        viewModel.unknownError.observe(this) {
+            Toast.makeText(this, it, Toast.LENGTH_SHORT).show()
+        }
     }
 }
 

--- a/common-ui/src/main/java/com/lgtm/android/common_ui/base/BaseFragment.kt
+++ b/common-ui/src/main/java/com/lgtm/android/common_ui/base/BaseFragment.kt
@@ -4,11 +4,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.annotation.LayoutRes
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
+import com.lgtm.android.common_ui.navigator.FakeSignInNavigator
 import com.lgtm.android.common_ui.util.KeyboardUtil
+import javax.inject.Inject
 
 abstract class BaseFragment<T : ViewDataBinding>(
     @LayoutRes private val layoutRes: Int
@@ -16,6 +19,14 @@ abstract class BaseFragment<T : ViewDataBinding>(
     private var _binding: T? = null
     protected val binding: T
         get() = requireNotNull(_binding)
+
+    lateinit var viewModel: BaseViewModel
+
+    @Inject
+    lateinit var signInNavigator: FakeSignInNavigator
+
+    abstract fun initializeViewModel()
+
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -26,6 +37,19 @@ abstract class BaseFragment<T : ViewDataBinding>(
         binding.lifecycleOwner = viewLifecycleOwner
         setSoftKeyboard()
         return binding.root
+    }
+
+    fun moveToSignInActivity() {
+        viewModel.moveToSignIn.observe(this) {
+            signInNavigator.navigateToSignIn()
+            requireActivity().finishAffinity()
+        }
+    }
+
+    fun makeToast() {
+        viewModel.unknownError.observe(this) {
+            Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+        }
     }
 
     private fun setSoftKeyboard() {

--- a/common-ui/src/main/java/com/lgtm/android/common_ui/base/BaseViewModel.kt
+++ b/common-ui/src/main/java/com/lgtm/android/common_ui/base/BaseViewModel.kt
@@ -1,0 +1,32 @@
+package com.lgtm.android.common_ui.base
+
+import android.content.ContentValues.TAG
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.lgtm.domain.entity.LgtmResponseException
+import kotlinx.coroutines.CoroutineExceptionHandler
+
+abstract class BaseViewModel : ViewModel() {
+
+    private val _moveToSignIn = MutableLiveData<Boolean>()
+    val moveToSignIn: LiveData<Boolean> = _moveToSignIn
+
+    private val _unknownError = MutableLiveData<String>() // make toast
+    val unknownError: LiveData<String> = _unknownError
+
+    val lgtmErrorHandler = CoroutineExceptionHandler { _, throwable ->
+        if (throwable is LgtmResponseException) {
+            when (throwable.httpCode) {
+                401 -> _moveToSignIn.postValue(true)
+                500 -> _unknownError.postValue("알 수 없는 오류가 발생했습니다.")
+                in 400..499 -> _unknownError.postValue(throwable.message)
+                else -> Log.e(
+                    TAG,
+                    "[LgtmNetworkError] Response code : ${throwable.responseCode}, Error Message :  ${throwable.message}"
+                )
+            }
+        }
+    }
+}

--- a/common-ui/src/main/java/com/lgtm/android/common_ui/navigator/FakeSignInNavigator.kt
+++ b/common-ui/src/main/java/com/lgtm/android/common_ui/navigator/FakeSignInNavigator.kt
@@ -1,0 +1,5 @@
+package com.lgtm.android.common_ui.navigator
+
+interface FakeSignInNavigator {
+    fun navigateToSignIn()
+}

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/SignInActivity.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/SignInActivity.kt
@@ -20,6 +20,10 @@ class SignInActivity : BaseActivity<ActivitySignInBinding>(R.layout.activity_sig
 
     private val signInViewModel by viewModels<SignInViewModel>()
 
+    override fun initializeViewModel() {
+        viewModel = signInViewModel
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setAnimationOnGithubButton()

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/SignInViewModel.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/SignInViewModel.kt
@@ -4,9 +4,9 @@ import android.content.ContentValues.TAG
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.gson.Gson
+import com.lgtm.android.common_ui.base.BaseViewModel
 import com.lgtm.android.common_ui.util.NetworkState
 import com.lgtm.domain.entity.LgtmResponseException
 import com.lgtm.domain.entity.response.GithubLoginResponse
@@ -18,7 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SignInViewModel @Inject constructor(
     private val authRepository: AuthRepository,
-) : ViewModel() {
+) : BaseViewModel() {
 
     private val deviceToken = MutableLiveData<String?>()
 
@@ -71,7 +71,7 @@ class SignInViewModel @Inject constructor(
     val patchDeviceTokenState: LiveData<NetworkState<Boolean>> = _patchDeviceTokenState
 
     fun patchDeviceToken() {
-        viewModelScope.launch {
+        viewModelScope.launch(lgtmErrorHandler) {
             val deviceToken: String? = deviceToken.value
             authRepository.patchDeviceToken(deviceToken)
                 .onSuccess {

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/SignUpActivity.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/SignUpActivity.kt
@@ -11,10 +11,13 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class SignUpActivity : BaseActivity<ActivitySignUpBinding>(R.layout.activity_sign_up) {
     private val signUpViewModel by viewModels<SignUpViewModel>()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         getExtraData()
+    }
+
+    override fun initializeViewModel() {
+        viewModel = signUpViewModel
     }
 
     private fun getExtraData() {

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/SignUpViewModel.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/SignUpViewModel.kt
@@ -2,10 +2,10 @@ package com.lgtm.android.auth.ui.signup
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.gson.Gson
 import com.lgtm.android.auth.exception.SignUpFailedException
+import com.lgtm.android.common_ui.base.BaseViewModel
 import com.lgtm.android.common_ui.constant.Bank
 import com.lgtm.android.common_ui.constant.BankHint
 import com.lgtm.android.common_ui.constant.BankList
@@ -28,7 +28,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SignUpViewModel @Inject constructor(
     private val authRepository: AuthRepository
-) : ViewModel() {
+) : BaseViewModel() {
 
     /** Device Token */
     private val deviceToken = MutableLiveData<String?>()
@@ -371,7 +371,7 @@ class SignUpViewModel @Inject constructor(
     val signUpState: LiveData<NetworkState<SignUpResponseVO>> = _signUpState
 
     fun signUpJunior() {
-        viewModelScope.launch {
+        viewModelScope.launch(lgtmErrorHandler) {
             try {
                 val signUpJuniorRequestVO = createSignUpJuniorRequestVO()
                 authRepository.signUpJunior(signUpJuniorRequestVO)
@@ -389,7 +389,7 @@ class SignUpViewModel @Inject constructor(
     }
 
     fun signUpSenior() {
-        viewModelScope.launch {
+        viewModelScope.launch(lgtmErrorHandler) {
             try {
                 val signUpSeniorRequestVO = createSignUpSeniorRequestVO()
                 authRepository.signUpSenior(signUpSeniorRequestVO)

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/common/ChooseRoleFragment.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/common/ChooseRoleFragment.kt
@@ -14,6 +14,9 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class ChooseRoleFragment : BaseFragment<FragmentChooseRoleBinding>(R.layout.fragment_choose_role) {
     private val signUpViewModel by activityViewModels<SignUpViewModel>()
+    override fun initializeViewModel() {
+        viewModel = signUpViewModel
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         setupViewModel()

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/common/IntroductionFragment.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/common/IntroductionFragment.kt
@@ -14,6 +14,9 @@ import dagger.hilt.android.AndroidEntryPoint
 class IntroductionFragment :
     BaseFragment<FragmentIntroductionBinding>(R.layout.fragment_introduction) {
     private val signUpViewModel by activityViewModels<SignUpViewModel>()
+    override fun initializeViewModel() {
+        viewModel = signUpViewModel
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         setupViewModel()

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/common/NicknameFragment.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/common/NicknameFragment.kt
@@ -14,6 +14,9 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class NicknameFragment : BaseFragment<FragmentNicknameBinding>(R.layout.fragment_nickname) {
     private val signUpViewModel by activityViewModels<SignUpViewModel>()
+    override fun initializeViewModel() {
+        viewModel = signUpViewModel
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         setupViewModel()

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/common/TechTagFragment.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/common/TechTagFragment.kt
@@ -14,6 +14,9 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class TechTagFragment : BaseFragment<FragmentTechTagBinding>(R.layout.fragment_tech_tag) {
     private val signUpViewModel by activityViewModels<SignUpViewModel>()
+    override fun initializeViewModel() {
+        viewModel = signUpViewModel
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         setupViewModel()

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/common/TermsFragment.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/common/TermsFragment.kt
@@ -15,6 +15,9 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class TermsFragment : BaseFragment<FragmentTermsBinding>(R.layout.fragment_terms) {
     private val signUpViewModel by activityViewModels<SignUpViewModel>()
+    override fun initializeViewModel() {
+        viewModel = signUpViewModel
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         setupViewModel()

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/reviewee/EducationStatusFragment.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/reviewee/EducationStatusFragment.kt
@@ -21,6 +21,9 @@ import com.lgtm.domain.constants.EducationStatus
 class EducationStatusFragment :
     BaseFragment<FragmentEducationStatusBinding>(R.layout.fragment_education_status) {
     private val signUpViewModel by activityViewModels<SignUpViewModel>()
+    override fun initializeViewModel() {
+        viewModel = signUpViewModel
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         setupRadioButtons()

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/reviewee/RealNameFragment.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/reviewee/RealNameFragment.kt
@@ -15,6 +15,9 @@ import com.lgtm.android.common_ui.util.NetworkState
 
 class RealNameFragment : BaseFragment<FragmentRealNameBinding>(R.layout.fragment_real_name) {
     private val signUpViewModel by activityViewModels<SignUpViewModel>()
+    override fun initializeViewModel() {
+        viewModel = signUpViewModel
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         setupViewModel()

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/reviewer/BankAccountFragment.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/reviewer/BankAccountFragment.kt
@@ -20,6 +20,9 @@ import com.lgtm.android.common_ui.util.NetworkState
 class BankAccountFragment :
     BaseFragment<FragmentBankAccountBinding>(R.layout.fragment_bank_account) {
     private val signUpViewModel by activityViewModels<SignUpViewModel>()
+    override fun initializeViewModel() {
+        viewModel = signUpViewModel
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         setupViewModel()

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/reviewer/CareerPeriodFragment.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/reviewer/CareerPeriodFragment.kt
@@ -14,6 +14,9 @@ import com.lgtm.android.common_ui.base.BaseFragment
 class CareerPeriodFragment :
     BaseFragment<FragmentCareerPeriodBinding>(R.layout.fragment_career_period) {
     private val signUpViewModel by activityViewModels<SignUpViewModel>()
+    override fun initializeViewModel() {
+        viewModel = signUpViewModel
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         setupViewModel()

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/reviewer/CompanyNameFragment.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/reviewer/CompanyNameFragment.kt
@@ -12,6 +12,9 @@ import com.lgtm.android.common_ui.base.BaseFragment
 class CompanyNameFragment :
     BaseFragment<FragmentCompanyNameBinding>(R.layout.fragment_company_name) {
     private val signUpViewModel by activityViewModels<SignUpViewModel>()
+    override fun initializeViewModel() {
+        viewModel = signUpViewModel
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         setupViewModel()

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/reviewer/PositionFragment.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/signup/reviewer/PositionFragment.kt
@@ -12,6 +12,9 @@ import com.lgtm.android.common_ui.base.BaseFragment
 class PositionFragment :
     BaseFragment<FragmentPositionBinding>(R.layout.fragment_position) {
     private val signUpViewModel by activityViewModels<SignUpViewModel>()
+    override fun initializeViewModel() {
+        viewModel = signUpViewModel
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         setupViewModel()

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/splash/SplashActivity.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/splash/SplashActivity.kt
@@ -17,6 +17,9 @@ import dagger.hilt.android.AndroidEntryPoint
 class SplashActivity : BaseActivity<ActivitySplashBinding>(R.layout.activity_splash) {
     private val splashViewModel by viewModels<SplashViewModel>()
     private lateinit var autoLoginState: AutoLoginState
+    override fun initializeViewModel() {
+        viewModel = splashViewModel
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/feature/auth/src/main/java/com/lgtm/android/auth/ui/splash/SplashViewModel.kt
+++ b/feature/auth/src/main/java/com/lgtm/android/auth/ui/splash/SplashViewModel.kt
@@ -4,8 +4,8 @@ import android.content.ContentValues.TAG
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.lgtm.android.common_ui.base.BaseViewModel
 import com.lgtm.domain.repository.AuthRepository
 import com.lgtm.domain.repository.IntroRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,7 +16,7 @@ import javax.inject.Inject
 class SplashViewModel @Inject constructor(
     private val introRepository: IntroRepository,
     private val authRepository: AuthRepository
-) : ViewModel() {
+) : BaseViewModel() {
     private val _minVersion = MutableLiveData<Int>()
     val minVersion: LiveData<Int> = _minVersion
 
@@ -24,7 +24,7 @@ class SplashViewModel @Inject constructor(
     val latestVersion: LiveData<Int> = _latestVersion
 
     fun getAppVersionInfo() {
-        viewModelScope.launch {
+        viewModelScope.launch(lgtmErrorHandler) {
             introRepository.getIntro()
                 .onSuccess {
                     _minVersion.value = it.minVersion


### PR DESCRIPTION
- closed #63 

- 멘토님! 전에 제안해 주신 Result의 **확장 함수** 방법은, **navigator를 hilt로 주입 받을 수가 없어서** BaseViewModel에 coroutine Exception handler를 사용하는 방법으로 변경했습니다.

- BaseActivity에 있는 viewmodel 변수와, 자식 Activity에 있는 viewModel을 필수적으로 연결 시켜주기 위해 abstract method를 활용했는데 이렇게 하는게 괜찮은 방법인지 궁금합니다
- 또한 `lgtmErrorHandler`에서 에러 코드로 에러 핸들링 하는 로직 괜찮은지 컨펌 부탁드립니다~!!