### PR TITLE
[FEAT] Mission 삭제 api 연동 (#153)

### DIFF
--- a/common-ui/src/main/res/values/strings.xml
+++ b/common-ui/src/main/res/values/strings.xml
@@ -144,6 +144,9 @@
     <string name="want_to_logout">로그아웃 하시겠어요?</string>
     <string name="cannot_cancle_after_participate_mission">참여한 미션은 취소가 불가능해요</string>
     <string name="do_you_want_to_participate_mission">미션에 참여하시겠어요?</string>
+    <string name="delete_mission_title">미션을 삭제하시겠어요?</string>
+    <string name="delete_mission_message">이미 미션에 참여한 리뷰이가 있다면 미션 삭제가 불가능합니다.</string>
+    <string name="delete_mission_success">미션이 삭제되었습니다.</string>
 
     <!-- Profile -->
     <string name="visit_github">Github 방문</string>

--- a/data/src/main/java/com/lgtm/android/data/datasource/MissionDataSource.kt
+++ b/data/src/main/java/com/lgtm/android/data/datasource/MissionDataSource.kt
@@ -9,6 +9,7 @@ import com.lgtm.android.data.model.response.PingPongSeniorDTO
 import com.lgtm.android.data.model.response.PostMissionResponseDTO
 import com.lgtm.android.data.service.MissionService
 import com.lgtm.domain.entity.request.PostMissionRequestDTO
+import com.lgtm.domain.entity.response.DeleteMissionResponse
 import com.lgtm.domain.entity.response.PingPongResponse
 import javax.inject.Inject
 
@@ -69,11 +70,19 @@ class MissionDataSource @Inject constructor(
         )
     }
 
-    suspend fun codeReviewCompleted(missionId: Int, juniorId: Int):  BaseDTO<PingPongResponse> {
+    suspend fun codeReviewCompleted(missionId: Int, juniorId: Int): BaseDTO<PingPongResponse> {
         return checkResponse(
             missionService.codeReviewCompleted(
                 missionId = missionId,
                 juniorId = juniorId
+            )
+        )
+    }
+
+    suspend fun deleteMission(missionId: Int): BaseDTO<DeleteMissionResponse> {
+        return checkResponse(
+            missionService.deleteMission(
+                missionId = missionId,
             )
         )
     }

--- a/data/src/main/java/com/lgtm/android/data/repository/MissionRepositoryImpl.kt
+++ b/data/src/main/java/com/lgtm/android/data/repository/MissionRepositoryImpl.kt
@@ -131,7 +131,10 @@ class MissionRepositoryImpl @Inject constructor(
             )
             Result.success(response.data.toVO())
         } catch (e: IllegalArgumentException) {
-            Log.e(TAG, "fetchSeniorMissionStatus: ${this.javaClass} ${e.message} / casting 도중 null 값 발생")
+            Log.e(
+                TAG,
+                "fetchSeniorMissionStatus: ${this.javaClass} ${e.message} / casting 도중 null 값 발생"
+            )
             Result.failure(e)
         } catch (e: Exception) {
             Log.e(TAG, "fetchSeniorMissionStatus: ${this.javaClass} ${e.message}")
@@ -171,6 +174,16 @@ class MissionRepositoryImpl @Inject constructor(
             Result.success(response.data.status != null)
         } catch (e: Exception) {
             Log.e(TAG, "codeReviewCompleted: ${this.javaClass} ${e.message}")
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun deleteMission(missionId: Int): Result<Boolean> {
+        return try {
+            val response = missionDataSource.deleteMission(missionId)
+            Result.success(response.data.writerId != null)
+        } catch (e: Exception) {
+            Log.e(TAG, "deleteMission: ${this.javaClass} ${e.message}")
             Result.failure(e)
         }
     }

--- a/data/src/main/java/com/lgtm/android/data/service/MissionService.kt
+++ b/data/src/main/java/com/lgtm/android/data/service/MissionService.kt
@@ -9,9 +9,11 @@ import com.lgtm.android.data.model.response.PingPongSeniorDTO
 import com.lgtm.android.data.model.response.PostMissionResponseDTO
 import com.lgtm.android.data.model.response.SduiDTO
 import com.lgtm.domain.entity.request.PostMissionRequestDTO
+import com.lgtm.domain.entity.response.DeleteMissionResponse
 import com.lgtm.domain.entity.response.PingPongResponse
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -80,5 +82,10 @@ interface MissionService {
         @Path("missionId") missionId: Int,
         @Path("juniorId") juniorId: Int
     ): Response<BaseDTO<PingPongResponse>>
+
+    @DELETE("v1/mission/{missionId}")
+    suspend fun deleteMission(
+        @Path("missionId") missionId: Int,
+    ): Response<BaseDTO<DeleteMissionResponse>>
 }
 

--- a/domain/src/main/java/com/lgtm/domain/entity/response/DeleteMissionResponse.kt
+++ b/domain/src/main/java/com/lgtm/domain/entity/response/DeleteMissionResponse.kt
@@ -1,0 +1,6 @@
+package com.lgtm.domain.entity.response
+
+data class DeleteMissionResponse(
+    val writerId: Int?,
+    val missionId: Int?
+)

--- a/domain/src/main/java/com/lgtm/domain/repository/MissionRepository.kt
+++ b/domain/src/main/java/com/lgtm/domain/repository/MissionRepository.kt
@@ -27,5 +27,5 @@ interface MissionRepository {
 
     suspend fun submitPullRequest(missionId: Int, githubPrUrl: String): Result<Boolean>
     suspend fun codeReviewCompleted(missionId: Int, juniorId: Int): Result<Boolean>
-
+    suspend fun deleteMission(missionId: Int): Result<Boolean>
 }

--- a/domain/src/main/java/com/lgtm/domain/usecase/MissionUseCase.kt
+++ b/domain/src/main/java/com/lgtm/domain/usecase/MissionUseCase.kt
@@ -208,6 +208,14 @@ class MissionUseCase @Inject constructor(
         }
     }
 
+    suspend fun deleteMission(missionId: Int): Result<Boolean> {
+        return try {
+            missionRepository.deleteMission(missionId)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     companion object {
         // viewType
         private const val ONGOING_MISSION_EMPTY_VIEW = "ongoing_mission_empty_view"

--- a/feature/mission_detail/src/main/java/com/lgtm/android/mission_detail/MissionDetailActivity.kt
+++ b/feature/mission_detail/src/main/java/com/lgtm/android/mission_detail/MissionDetailActivity.kt
@@ -20,7 +20,6 @@ import com.lgtm.android.common_ui.ui.LgtmConfirmationDialog
 import com.lgtm.android.common_ui.util.NetworkState
 import com.lgtm.android.common_ui.util.getDrawableCompat
 import com.lgtm.android.mission_detail.databinding.ActivityMissionDetailBinding
-import com.lgtm.domain.constants.MissionDetailStatus
 import com.lgtm.domain.constants.MissionDetailStatus.JUNIOR_NOT_PARTICIPATE_MISSION_FINISH
 import com.lgtm.domain.constants.MissionDetailStatus.JUNIOR_NOT_PARTICIPATE_RECRUITING
 import com.lgtm.domain.constants.MissionDetailStatus.JUNIOR_PARTICIPATE_MISSION_FINISH
@@ -81,7 +80,7 @@ class MissionDetailActivity :
     private fun observeMissionDetailUiState() {
         missionDetailViewModel.missionDetailStatus.observe(this) {
             when (it) {
-                is NetworkState.Init -> {} // no-op
+                is NetworkState.Init -> { /* no-op */}
                 is NetworkState.Success -> {
                     val missionDetailUi = missionDetailViewModel.missionDetailUiState.value
                     missionDetailViewModel.setRecommendToEmptyVisibility()
@@ -89,6 +88,7 @@ class MissionDetailActivity :
                     techTagAdapter.submitList(missionDetailUi?.techTagList)
                     binding.profileGlance.data = requireNotNull(missionDetailUi?.memberProfile)
                 }
+
                 is NetworkState.Failure -> {
                     Toast.makeText(this, it.msg, Toast.LENGTH_SHORT).show()
                 }
@@ -202,7 +202,7 @@ class MissionDetailActivity :
     private fun observeDeleteMissionStatus() {
         missionDetailViewModel.deleteMissionState.observe(this) {
             when (it) {
-                is NetworkState.Init -> {} /* no-op*/
+                is NetworkState.Init -> { /* no-op*/ }
                 is NetworkState.Success -> {
                     showMissionDeleteSuccessToast()
                     finish()
@@ -231,7 +231,7 @@ class MissionDetailActivity :
 
     private fun setOnClickBottomButton() {
         binding.btnMissionDetail.setOnClickListener {
-            val missionDetailStatus: MissionDetailStatus =
+            val missionDetailStatus =
                 missionDetailViewModel.getMissionDetailStatus() ?: return@setOnClickListener
             when (missionDetailStatus) {
                 JUNIOR_PARTICIPATE_RECRUITING -> navigateJuniorMyMission()

--- a/feature/mission_detail/src/main/java/com/lgtm/android/mission_detail/MissionDetailActivity.kt
+++ b/feature/mission_detail/src/main/java/com/lgtm/android/mission_detail/MissionDetailActivity.kt
@@ -79,11 +79,20 @@ class MissionDetailActivity :
     }
 
     private fun observeMissionDetailUiState() {
-        missionDetailViewModel.missionDetailUiState.observe(this) {
-            missionDetailViewModel.setRecommendToEmptyVisibility()
-            missionDetailViewModel.setNotRecommendToEmptyVisibility()
-            techTagAdapter.submitList(it.techTagList)
-            binding.profileGlance.data = requireNotNull(it.memberProfile)
+        missionDetailViewModel.missionDetailStatus.observe(this) {
+            when (it) {
+                is NetworkState.Init -> {} // no-op
+                is NetworkState.Success -> {
+                    val missionDetailUi = missionDetailViewModel.missionDetailUiState.value
+                    missionDetailViewModel.setRecommendToEmptyVisibility()
+                    missionDetailViewModel.setNotRecommendToEmptyVisibility()
+                    techTagAdapter.submitList(missionDetailUi?.techTagList)
+                    binding.profileGlance.data = requireNotNull(missionDetailUi?.memberProfile)
+                }
+                is NetworkState.Failure -> {
+                    Toast.makeText(this, it.msg, Toast.LENGTH_SHORT).show()
+                }
+            }
         }
     }
 

--- a/feature/mission_detail/src/main/java/com/lgtm/android/mission_detail/MissionDetailActivity.kt
+++ b/feature/mission_detail/src/main/java/com/lgtm/android/mission_detail/MissionDetailActivity.kt
@@ -58,6 +58,7 @@ class MissionDetailActivity :
         initAdapter()
         setRecyclerViewLayoutManager()
         observeParticipateMissionUiState()
+        observeDeleteMissionStatus()
     }
 
     override fun onResume() {
@@ -159,23 +160,54 @@ class MissionDetailActivity :
 
     override fun onMenuItemClick(item: MenuItem): Boolean {
         return when (item.itemId) {
-            id.report -> {
+            id.report, id.edit_profile -> {
                 Toast.makeText(this, string.service_under_preparation, Toast.LENGTH_SHORT).show()
                 true
             }
 
             id.delete_mission -> {
-                Toast.makeText(this, string.service_under_preparation, Toast.LENGTH_SHORT).show()
-                true
-            }
-
-            id.edit_profile -> {
-                Toast.makeText(this, string.service_under_preparation, Toast.LENGTH_SHORT).show()
+                showDeleteMissionDialog()
                 true
             }
 
             else -> false
         }
+    }
+
+    private fun showDeleteMissionDialog() {
+        val title = getString(string.delete_mission_title)
+        val description = getString(string.delete_mission_message)
+        val dialog = LgtmConfirmationDialog(
+            title = title,
+            description = description,
+            doAfterConfirm = ::deleteMission,
+            confirmBtnBackground = LgtmConfirmationDialog.ConfirmButtonBackground.GREEN
+        )
+        dialog.show(supportFragmentManager, this.javaClass.name)
+    }
+
+    private fun deleteMission() {
+        missionDetailViewModel.deleteMission()
+    }
+
+    private fun observeDeleteMissionStatus() {
+        missionDetailViewModel.deleteMissionState.observe(this) {
+            when (it) {
+                is NetworkState.Init -> {} /* no-op*/
+                is NetworkState.Success -> {
+                    showMissionDeleteSuccessToast()
+                    finish()
+                }
+
+                is NetworkState.Failure -> {
+                    Toast.makeText(this, it.msg, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    private fun showMissionDeleteSuccessToast() {
+        Toast.makeText(this, getString(string.delete_mission_success), Toast.LENGTH_SHORT).show()
     }
 
     private fun setOnMissionUrlClickListener() {

--- a/feature/mission_detail/src/main/java/com/lgtm/android/mission_detail/MissionDetailViewModel.kt
+++ b/feature/mission_detail/src/main/java/com/lgtm/android/mission_detail/MissionDetailViewModel.kt
@@ -36,6 +36,14 @@ class MissionDetailViewModel @Inject constructor(
         MutableLiveData(NetworkState.Init)
     val participateMissionUiState: LiveData<NetworkState<Boolean>> = _participateMissionUiState
 
+    private val _deleteMissionState: MutableLiveData<NetworkState<Boolean>> =
+        MutableLiveData(NetworkState.Init)
+    val deleteMissionState: LiveData<NetworkState<Boolean>> = _deleteMissionState
+
+    private val _missionDetailStatus: MutableLiveData<NetworkState<Boolean>> =
+        MutableLiveData(NetworkState.Init)
+    val missionDetailStatus: LiveData<NetworkState<Boolean>> = _missionDetailStatus
+
     fun isMyMission() =
         _missionDetailVO.value?.missionDetailStatus == MissionDetailStatus.SENIOR_PARTICIPATE_RECRUITING ||
                 _missionDetailVO.value?.missionDetailStatus == MissionDetailStatus.SENIOR_PARTICIPATE_MISSION_FINISH
@@ -74,7 +82,9 @@ class MissionDetailViewModel @Inject constructor(
                 .onSuccess {
                     _missionDetailVO.postValue(it)
                     _missionDetailUiState.postValue(it.toUiModel())
+                    _missionDetailStatus.postValue(NetworkState.Success(true))
                 }.onFailure {
+                    _missionDetailStatus.postValue(NetworkState.Failure(it.message))
                     Log.e(TAG, "getMissionDetail: $it")
                 }
         }
@@ -93,4 +103,15 @@ class MissionDetailViewModel @Inject constructor(
     }
 
     fun getMissionId() = _missionDetailVO.value?.missionId ?: -1
+    fun deleteMission() {
+        val missionId = _missionDetailVO.value?.missionId ?: return
+        viewModelScope.launch(lgtmErrorHandler) {
+            missionUseCase.deleteMission(missionId)
+                .onSuccess {
+                    _deleteMissionState.postValue(NetworkState.Success(it))
+                }.onFailure {
+                    _deleteMissionState.postValue(NetworkState.Failure(it.message))
+                }
+        }
+    }
 }


### PR DESCRIPTION
- closed #153

### To Designer
어진센세~ 미션 삭제 테스트 진행 방법입니다 :)

**[성공 로직]**
1. kxxhyorim 테스트 계정으로 로그인
2. 미션 생성하기
3. 방금 생성한 미션 삭제하기
    - 미션 삭제 확인 dialog 올라옴
    - **워딩 괜찮은지, '예' 버튼을 초록색으로 하는게 맞는지 확인 부탁드립니다**✅
5. 1️⃣ '미션이 삭제되었습니다' Toast 발생 
2️⃣ 해당 미션 화면이 꺼집니다


**[실패 로직]**
1. home 화면에서 '내가 참여중인 미션'에서 아무거나 선택
2. 현재 참여중인 리뷰이가 있는지 확인
3. 리뷰이가 있다면, '미션 삭제' 클릭
4. '이미 참여중인 사람이 있어서 미션 삭제 못한다'는 toast 보여짐
