### PR TITLE
[FEAT] Notification Center / Timestamp 추가

### DIFF
--- a/common-ui/src/main/java/com/lgtm/android/common_ui/model/NotificationUI.kt
+++ b/common-ui/src/main/java/com/lgtm/android/common_ui/model/NotificationUI.kt
@@ -1,0 +1,10 @@
+package com.lgtm.android.common_ui.model
+
+data class NotificationUI(
+    val title: String,
+    val body: String,
+    val isRead: Boolean,
+    val notificationId: Int,
+    val date: String,
+    val time: String,
+)

--- a/common-ui/src/main/java/com/lgtm/android/common_ui/model/mapper/UiMapper.kt
+++ b/common-ui/src/main/java/com/lgtm/android/common_ui/model/mapper/UiMapper.kt
@@ -32,15 +32,15 @@ import com.lgtm.domain.entity.response.PingPongSeniorVO
 import com.lgtm.domain.entity.response.ProfileVO
 import com.lgtm.domain.mission_suggestion.SuggestionVO
 import com.lgtm.domain.profile.profileViewType.ProfileGlance
-import com.lgtm.domain.util.dotStyleFormatter
-import com.lgtm.domain.util.timeFormatter
+import com.lgtm.domain.util.dotStyleDateFormatter
+import com.lgtm.domain.util.korean12HourTimeFormatter
 import java.time.LocalDateTime
 
 fun MissionDetailVO.toUiModel(): MissionDetailUI = MissionDetailUI(
     currentPeopleNumber = currentPeopleNumber,
     description = description,
     maxPeopleNumber = maxPeopleNumber,
-    memberProfile = memberProfile.toUiModel(memberType),
+    memberProfile = memberProfile.toUiModel(),
     memberType = memberType,
     missionId = missionId,
     missionRepositoryUrl = missionRepositoryUrl,
@@ -55,7 +55,7 @@ fun MissionDetailVO.toUiModel(): MissionDetailUI = MissionDetailUI(
     missionDetailButtonStatusUI = getButtonStatusUI(missionDetailStatus)
 )
 
-fun ProfileVO.toUiModel(role: Role): ProfileGlanceUI = ProfileGlanceUI(
+fun ProfileVO.toUiModel(): ProfileGlanceUI = ProfileGlanceUI(
     memberId = memberId,
     profileImage = profileImageUrl,
     nickname = nickname,
@@ -223,8 +223,8 @@ fun SuggestionVO.toUiModel(): SuggestionUI {
         title = title,
         description = description,
         suggestionId = suggestionId,
-        date = localDateTime.format(dotStyleFormatter),
-        time = localDateTime.format(timeFormatter),
+        date = localDateTime.format(dotStyleDateFormatter),
+        time = localDateTime.format(korean12HourTimeFormatter),
         likeNum = likeNum,
         isLiked = isLiked,
         isMyPost = isMyPost
@@ -237,7 +237,7 @@ fun NotificationVO.toUiModel(): NotificationUI {
         body = body,
         notificationId = notificationId,
         isRead = isRead,
-        time = date?.format(timeFormatter) ?: "",
-        date = date?.format(dotStyleFormatter) ?: ""
+        time = date?.format(korean12HourTimeFormatter) ?: "",
+        date = date?.format(dotStyleDateFormatter) ?: ""
     )
 }

--- a/common-ui/src/main/java/com/lgtm/android/common_ui/model/mapper/UiMapper.kt
+++ b/common-ui/src/main/java/com/lgtm/android/common_ui/model/mapper/UiMapper.kt
@@ -13,6 +13,7 @@ import com.lgtm.android.common_ui.model.DashboardUI
 import com.lgtm.android.common_ui.model.MemberMissionStatusUI
 import com.lgtm.android.common_ui.model.MissionDetailUI
 import com.lgtm.android.common_ui.model.MissionProcessInfoUI
+import com.lgtm.android.common_ui.model.NotificationUI
 import com.lgtm.android.common_ui.model.PingPongJuniorUI
 import com.lgtm.android.common_ui.model.PingPongSeniorUI
 import com.lgtm.android.common_ui.model.ProfileGlanceUI
@@ -25,6 +26,7 @@ import com.lgtm.domain.entity.response.DashboardVO
 import com.lgtm.domain.entity.response.MemberMissionStatusVO
 import com.lgtm.domain.entity.response.MissionDetailVO
 import com.lgtm.domain.entity.response.MissionProcessInfoVO
+import com.lgtm.domain.entity.response.NotificationVO
 import com.lgtm.domain.entity.response.PingPongJuniorVO
 import com.lgtm.domain.entity.response.PingPongSeniorVO
 import com.lgtm.domain.entity.response.ProfileVO
@@ -226,5 +228,16 @@ fun SuggestionVO.toUiModel(): SuggestionUI {
         likeNum = likeNum,
         isLiked = isLiked,
         isMyPost = isMyPost
+    )
+}
+
+fun NotificationVO.toUiModel(): NotificationUI {
+    return NotificationUI(
+        title = title,
+        body = body,
+        notificationId = notificationId,
+        isRead = isRead,
+        time = date?.format(timeFormatter) ?: "",
+        date = date?.format(dotStyleFormatter) ?: ""
     )
 }

--- a/common-ui/src/main/java/com/lgtm/android/common_ui/ui/LGTMTimestamp.kt
+++ b/common-ui/src/main/java/com/lgtm/android/common_ui/ui/LGTMTimestamp.kt
@@ -1,0 +1,27 @@
+package com.lgtm.android.common_ui.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.lgtm.android.common_ui.databinding.LayoutLgtmTimestampBinding
+
+class LGTMTimestamp @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : ConstraintLayout(context, attrs, defStyleAttr) {
+
+    private val binding: LayoutLgtmTimestampBinding by lazy {
+        LayoutLgtmTimestampBinding.inflate(LayoutInflater.from(context), this, false)
+    }
+
+    fun setTimeStamp(date: String, time: String) {
+        binding.tvDate.text = date
+        binding.tvTime.text = time
+    }
+
+    init {
+        addView(binding.root)
+    }
+}

--- a/common-ui/src/main/res/layout/layout_lgtm_timestamp.xml
+++ b/common-ui/src/main/res/layout/layout_lgtm_timestamp.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/tv_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/Description"
+            android:textColor="@color/gray_5"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="2023.02.25" />
+
+        <View
+            android:id="@+id/v_divider"
+            android:layout_width="1dp"
+            android:layout_height="0dp"
+            android:layout_marginVertical="2dp"
+            android:layout_marginStart="3dp"
+            android:background="@color/gray_3"
+            app:layout_constraintBottom_toBottomOf="@id/tv_date"
+            app:layout_constraintStart_toEndOf="@id/tv_date"
+            app:layout_constraintTop_toTopOf="@id/tv_date" />
+
+        <TextView
+            android:id="@+id/tv_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="3dp"
+            android:textAppearance="@style/Description"
+            android:textColor="@color/gray_5"
+            app:layout_constraintBottom_toBottomOf="@id/tv_date"
+            app:layout_constraintStart_toEndOf="@id/v_divider"
+            app:layout_constraintTop_toTopOf="@id/tv_date"
+            tools:text="오후 12:00" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
     implementation(libs.hilt)
     kapt(libs.hilt.kapt)
     implementation(libs.bundles.basic.test)
+    api(platform(libs.firebase))
+    api(libs.bundles.firebase)
 
     // app 모듈에 전달 (NetworkModule)
     api(libs.bundles.retrofit)

--- a/data/src/main/java/com/lgtm/android/data/model/response/NotificationDTO.kt
+++ b/data/src/main/java/com/lgtm/android/data/model/response/NotificationDTO.kt
@@ -1,19 +1,38 @@
 package com.lgtm.android.data.model.response
 
+import com.google.firebase.crashlytics.ktx.crashlytics
+import com.google.firebase.ktx.Firebase
 import com.lgtm.domain.entity.response.NotificationVO
+import java.time.LocalDateTime
+import java.time.format.DateTimeParseException
 
 data class NotificationDTO(
     val body: String?,
     val isRead: Boolean?,
     val notificationId: Int?,
     val title: String?,
+    val createdAt: String?,
 ) {
     fun toVO(): NotificationVO {
         return NotificationVO(
-            title = title ?: "",
-            body = body ?: "",
+            title = title.orEmpty(),
+            body = body.orEmpty(),
             isRead = isRead ?: false,
-            notificationId = notificationId ?: throw IllegalArgumentException("notificationId is null")
+            notificationId = requireNotNull(notificationId) { "notificationId is null" },
+            date = parseDate()
         )
+    }
+
+    private fun parseDate(): LocalDateTime? {
+        return try {
+            checkNotNull(createdAt)
+            LocalDateTime.parse(createdAt)
+        } catch (e: DateTimeParseException) {
+            Firebase.crashlytics.log("$e / Wrong Date format : $createdAt")
+            null
+        } catch (e: IllegalStateException) {
+            Firebase.crashlytics.log("$e / created value might be null : $createdAt")
+            null
+        }
     }
 }

--- a/domain/src/main/java/com/lgtm/domain/entity/response/NotificationVO.kt
+++ b/domain/src/main/java/com/lgtm/domain/entity/response/NotificationVO.kt
@@ -1,8 +1,11 @@
 package com.lgtm.domain.entity.response
 
+import java.time.LocalDateTime
+
 data class NotificationVO(
     val title: String,
     val body: String,
     val isRead: Boolean,
     val notificationId: Int,
+    val date: LocalDateTime?,
 )

--- a/domain/src/main/java/com/lgtm/domain/usecase/MissionUseCase.kt
+++ b/domain/src/main/java/com/lgtm/domain/usecase/MissionUseCase.kt
@@ -14,7 +14,7 @@ import com.lgtm.domain.server_drive_ui.SduiContent
 import com.lgtm.domain.server_drive_ui.SduiEmptyUiState
 import com.lgtm.domain.server_drive_ui.SduiViewType
 import com.lgtm.domain.server_drive_ui.SectionEmptyVO
-import com.lgtm.domain.util.dotStyleFormatter
+import com.lgtm.domain.util.dotStyleDateFormatter
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.jsoup.Jsoup
@@ -137,7 +137,7 @@ class MissionUseCase @Inject constructor(
     private fun convertTimestampToCustomFormat(timestamp: String?): String {
         if (timestamp == null || timestamp == "") return "-"
         val localDateTime = LocalDateTime.parse(timestamp)
-        return localDateTime.format(dotStyleFormatter)
+        return localDateTime.format(dotStyleDateFormatter)
     }
 
     suspend fun confirmJuniorPayment(missionID: Int): Result<Boolean> {

--- a/domain/src/main/java/com/lgtm/domain/util/LgtmDateFormatter.kt
+++ b/domain/src/main/java/com/lgtm/domain/util/LgtmDateFormatter.kt
@@ -1,7 +1,9 @@
 package com.lgtm.domain.util
 
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 val dotStyleFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
 val isoStyleFormatter: DateTimeFormatter = DateTimeFormatter.ISO_DATE
-val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("a h:mm")
+val timeFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("a h:mm").withLocale(Locale("ko", "KR"))

--- a/domain/src/main/java/com/lgtm/domain/util/LgtmDateTimeFormatter.kt
+++ b/domain/src/main/java/com/lgtm/domain/util/LgtmDateTimeFormatter.kt
@@ -3,7 +3,7 @@ package com.lgtm.domain.util
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
-val dotStyleFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+val dotStyleDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
 val isoStyleFormatter: DateTimeFormatter = DateTimeFormatter.ISO_DATE
-val timeFormatter: DateTimeFormatter =
+val korean12HourTimeFormatter: DateTimeFormatter =
     DateTimeFormatter.ofPattern("a h:mm").withLocale(Locale("ko", "KR"))

--- a/feature/auth/src/main/res/layout/fragment_position.xml
+++ b/feature/auth/src/main/res/layout/fragment_position.xml
@@ -42,7 +42,7 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="24dp"
             android:layout_marginTop="53dp"
-            app:layout_constraintTop_toBottomOf="@id/tv_enter_position" />
+            app:layout_constraintTop_toBottomOf="@id/tv_position_example" />
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_next"

--- a/feature/create_mission/src/main/java/com/lgtm/android/create_mission/CreateMissionStep5Fragment.kt
+++ b/feature/create_mission/src/main/java/com/lgtm/android/create_mission/CreateMissionStep5Fragment.kt
@@ -10,7 +10,7 @@ import com.lgtm.android.common_ui.base.BaseFragment
 import com.lgtm.android.common_ui.util.NetworkState
 import com.lgtm.android.common_ui.util.setOnThrottleClickListener
 import com.lgtm.android.create_mission.databinding.FragmentCreateMissionStep5Binding
-import com.lgtm.domain.util.dotStyleFormatter
+import com.lgtm.domain.util.dotStyleDateFormatter
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDate
 import java.util.Calendar
@@ -46,7 +46,7 @@ class CreateMissionStep5Fragment :
     }
 
     private fun setFormattedDate(localDate: LocalDate) {
-        val formattedDate = localDate.format(dotStyleFormatter)
+        val formattedDate = localDate.format(dotStyleDateFormatter)
         binding.etRegistrationDueDate.setText(formattedDate)
     }
 

--- a/feature/main/src/main/java/com/lgtm/android/main/notification/NotificationAdapter.kt
+++ b/feature/main/src/main/java/com/lgtm/android/main/notification/NotificationAdapter.kt
@@ -4,12 +4,12 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.lgtm.android.common_ui.model.NotificationUI
 import com.lgtm.android.common_ui.util.ItemDiffCallback
 import com.lgtm.android.main.databinding.ItemNotificationCenterBinding
-import com.lgtm.domain.entity.response.NotificationVO
 
-class NotificationAdapter : ListAdapter<NotificationVO, NotificationViewHolder>(
-    ItemDiffCallback<NotificationVO>(
+class NotificationAdapter : ListAdapter<NotificationUI, NotificationViewHolder>(
+    ItemDiffCallback<NotificationUI>(
         onContentsTheSame = { old, new -> old == new },
         onItemsTheSame = { old, new -> old.notificationId == new.notificationId })
 ) {
@@ -28,7 +28,8 @@ class NotificationAdapter : ListAdapter<NotificationVO, NotificationViewHolder>(
 class NotificationViewHolder(
     private val binding: ItemNotificationCenterBinding,
 ) : RecyclerView.ViewHolder(binding.root) {
-    fun onBind(item: NotificationVO) {
+    fun onBind(item: NotificationUI) {
         binding.data = item
+        binding.lgtmTimestamp.setTimeStamp(item.date, item.time)
     }
 }

--- a/feature/main/src/main/java/com/lgtm/android/main/notification/NotificationCenterViewModel.kt
+++ b/feature/main/src/main/java/com/lgtm/android/main/notification/NotificationCenterViewModel.kt
@@ -8,7 +8,8 @@ import androidx.lifecycle.viewModelScope
 import com.google.firebase.crashlytics.ktx.crashlytics
 import com.google.firebase.ktx.Firebase
 import com.lgtm.android.common_ui.base.BaseViewModel
-import com.lgtm.domain.entity.response.NotificationVO
+import com.lgtm.android.common_ui.model.NotificationUI
+import com.lgtm.android.common_ui.model.mapper.toUiModel
 import com.lgtm.domain.repository.NotificationRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -19,13 +20,13 @@ class NotificationCenterViewModel @Inject constructor(
     private val notificationRepository: NotificationRepository,
 ) : BaseViewModel() {
 
-    private val _notificationList = MutableLiveData<List<NotificationVO>>()
-    val notificationList: LiveData<List<NotificationVO>> = _notificationList
+    private val _notificationList = MutableLiveData<List<NotificationUI>>()
+    val notificationList: LiveData<List<NotificationUI>> = _notificationList
     fun getNotificationList() {
         viewModelScope.launch(lgtmErrorHandler) {
             notificationRepository.getNotificationList()
-                .onSuccess {
-                    _notificationList.postValue(it)
+                .onSuccess { it ->
+                    _notificationList.postValue(it.map { it.toUiModel() })
                 }.onFailure {
                     Firebase.crashlytics.recordException(it)
                     Log.e(TAG, "getNotificationList: $it")

--- a/feature/main/src/main/java/com/lgtm/android/main/setting/MyPageViewModel.kt
+++ b/feature/main/src/main/java/com/lgtm/android/main/setting/MyPageViewModel.kt
@@ -32,7 +32,7 @@ class MyPageViewModel @Inject constructor(
         viewModelScope.launch(lgtmErrorHandler) {
             profileRepository.getProfileInfo()
                 .onSuccess {
-                    _profileInfo.postValue(it.toUiModel(requireNotNull(it.memberType)))
+                    _profileInfo.postValue(it.toUiModel())
                 }.onFailure {
                     Firebase.crashlytics.recordException(it)
                     Log.e(TAG, "getProfileInfo: $it")

--- a/feature/main/src/main/res/layout/item_notification_center.xml
+++ b/feature/main/src/main/res/layout/item_notification_center.xml
@@ -7,7 +7,7 @@
 
         <variable
             name="data"
-            type="com.lgtm.domain.entity.response.NotificationVO" />
+            type="com.lgtm.android.common_ui.model.NotificationUI" />
 
     </data>
 
@@ -52,12 +52,20 @@
             android:layout_marginBottom="24dp"
             android:text="@{data.body}"
             android:textAppearance="@style/Description"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/iv_notification_icon"
             app:layout_constraintTop_toBottomOf="@id/tv_notification_title"
             tools:text="This is Body Part." />
 
+        <com.lgtm.android.common_ui.ui.LGTMTimestamp
+            android:id="@+id/lgtm_timestamp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="20dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="@id/tv_notification_body"
+            app:layout_constraintTop_toBottomOf="@id/tv_notification_body" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
### 결과물 📱

<img width="300" alt="image" src="https://github.com/hellokitty-coding-club/LGTM-Android/assets/59546818/ee2312e6-2eba-4acd-9a51-17d1ea779ca0">


### 전달사항
#### 1. LGTMTimestamp class 추가
- 유리아! `LGTMTimestamp` class 추가했어. 여러 화면에서 많이 쓰일것같아서 ㅎㅎ 
- `setTimeStamp()`함수로 시간 지정해줄수 있어!


#### 2. TimeFormatter 변경
- 기존에 유리가 추가해준대로 pattern만 "a h:mm"로 지정한 경우에는 Default Locale에 따라서 String이 나오더라구
- 내 에뮬에서 기본 언어가 Eng로 지정되어 있으면 '오전/오후' 대신 'AM/PM'으로 표기돼서 우선 Ko-kr locale 명시적으로 지정해줬어!
- 네이밍도 좀 구체적으로 수정했다! `korean12HourTimeFormatter`