### PR TITLE
[FEAT] 미션 제안 상세 화면 기능 구현 마무리 (#219)

### DIFF
--- a/common-ui/src/main/java/com/lgtm/android/common_ui/components/buttons/LikeButton.kt
+++ b/common-ui/src/main/java/com/lgtm/android/common_ui/components/buttons/LikeButton.kt
@@ -18,12 +18,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lgtm.android.common_ui.R
 import com.lgtm.android.common_ui.theme.LGTMTheme
+import com.lgtm.android.common_ui.util.throttleClickable
 
 @Composable
 fun LikeButton(
+    modifier: Modifier = Modifier,
     likeNum: String,
     isLiked: Boolean,
-    modifier: Modifier = Modifier
+    onClick: () -> Unit
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -41,6 +43,10 @@ fun LikeButton(
                 horizontal = 6.dp,
                 vertical = 9.dp
             )
+            .throttleClickable(
+                enabled = true,
+                onClick = onClick
+            )
     ) {
         
         Text(
@@ -53,7 +59,7 @@ fun LikeButton(
 
         Image(
             modifier = Modifier.padding(start = 2.dp),
-            imageVector = ImageVector.vectorResource(id = R.drawable.ic_like_selected),
+            imageVector = if (isLiked) ImageVector.vectorResource(id = R.drawable.ic_like_selected) else ImageVector.vectorResource(id = R.drawable.ic_like_unselected),
             contentDescription = null
         )
     }
@@ -65,7 +71,8 @@ fun LikeButtonPreview() {
     LGTMTheme {
         LikeButton(
             likeNum = "22",
-            isLiked = true
+            isLiked = true,
+            onClick = {}
         )
     }
 }

--- a/common-ui/src/main/java/com/lgtm/android/common_ui/components/buttons/MenuButton.kt
+++ b/common-ui/src/main/java/com/lgtm/android/common_ui/components/buttons/MenuButton.kt
@@ -8,33 +8,56 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lgtm.android.common_ui.R
 import com.lgtm.android.common_ui.theme.LGTMTheme
+import com.lgtm.android.common_ui.util.throttleClickable
 
 @Composable
 fun MenuButton(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    dropDownContent: @Composable (expanded: Boolean, onDismissRequest: () -> Unit) -> Unit
 ) {
+    var dropDownExpanded by remember { mutableStateOf(false) }
+
     Box(
         modifier = modifier
             .wrapContentSize()
             .border(
                 width = 1.dp,
-                color = LGTMTheme.colors.gray_3,
+                color = if (!dropDownExpanded) LGTMTheme.colors.gray_3 else LGTMTheme.colors.black,
                 shape = RoundedCornerShape(10.dp)
             )
             .background(
-                color = LGTMTheme.colors.white,
+                color = if (!dropDownExpanded) LGTMTheme.colors.white else LGTMTheme.colors.black,
                 shape = RoundedCornerShape(10.dp)
             )
             .padding(3.dp)
+            .throttleClickable(enabled = true) {
+                dropDownExpanded = !dropDownExpanded
+            }
     ) {
         Image(
-            painter = painterResource(id = R.drawable.ic_menu_black),
+            painter = if (!dropDownExpanded) painterResource(id = R.drawable.ic_menu_black) else painterResource(id = R.drawable.ic_menu_green),
             contentDescription = null
         )
+        dropDownContent(dropDownExpanded) {
+            dropDownExpanded = false
+        }
+    }
+}
+
+@Preview
+@Composable
+fun MenuButtonPreview() {
+    LGTMTheme {
+        MenuButton {_, _ -> }
     }
 }

--- a/common-ui/src/main/java/com/lgtm/android/common_ui/components/dialog/LgtmConfirmationDialog.kt
+++ b/common-ui/src/main/java/com/lgtm/android/common_ui/components/dialog/LgtmConfirmationDialog.kt
@@ -7,8 +7,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -18,9 +23,51 @@ import com.lgtm.android.common_ui.R
 import com.lgtm.android.common_ui.components.buttons.ConfirmButtonBackgroundColor
 import com.lgtm.android.common_ui.components.buttons.DialogConfirmationButton
 import com.lgtm.android.common_ui.theme.LGTMTheme
+import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun LgtmConfirmationDialog(
+    bottomSheetState: ModalBottomSheetState,
+    dialogTitle: String,
+    dialogDescription: String? = null,
+    onClickConfirm: () -> Unit,
+    confirmBtnBackground: ConfirmButtonBackgroundColor,
+    content: @Composable () -> Unit
+) {
+    val coroutineScope = rememberCoroutineScope()
+
+    ModalBottomSheetLayout(
+        sheetState = bottomSheetState,
+        sheetShape = RoundedCornerShape(
+            topStart = 20.dp,
+            topEnd = 20.dp
+        ),
+        scrimColor = LGTMTheme.colors.transparent_black,
+        sheetContent = {
+            LgtmConfirmationDialogContent(
+                dialogTitle = dialogTitle,
+                dialogDescription = dialogDescription,
+                onClickCancel = {
+                    coroutineScope.launch {
+                        bottomSheetState.hide()
+                    }
+                },
+                onClickConfirm = {
+                    coroutineScope.launch {
+                        bottomSheetState.hide()
+                        onClickConfirm()
+                    }
+                },
+                confirmBtnBackground = confirmBtnBackground
+            )
+        },
+        content = content
+    )
+}
+
+@Composable
+fun LgtmConfirmationDialogContent(
     dialogTitle: String,
     dialogDescription: String? = null,
     onClickCancel: () -> Unit,
@@ -91,7 +138,7 @@ fun DialogButtons(
 @Preview
 fun LGTMBottomSheetDialogContentPreview() {
     LGTMTheme {
-        LgtmConfirmationDialog(
+        LgtmConfirmationDialogContent(
             dialogTitle = "작성을 중단할까요?",
             dialogDescription = "작성한 내용은 저장되지 않아요.",
             onClickCancel = {},

--- a/common-ui/src/main/java/com/lgtm/android/common_ui/components/dropdown/SuggestionDropDownOneMenu.kt
+++ b/common-ui/src/main/java/com/lgtm/android/common_ui/components/dropdown/SuggestionDropDownOneMenu.kt
@@ -1,0 +1,47 @@
+package com.lgtm.android.common_ui.components.dropdown
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.lgtm.android.common_ui.theme.LGTMTheme
+
+@Composable
+fun SuggestionDropDownOneMenu(
+    isExpanded: Boolean,
+    text: String,
+    onDismissRequest: () -> Unit,
+    onMenuClick: () -> Unit
+) {
+    MaterialTheme(shapes = MaterialTheme.shapes.copy(medium = RoundedCornerShape(10.dp))) {
+        DropdownMenu(
+            modifier = Modifier
+                .background(
+                    color = LGTMTheme.colors.white
+                )
+                .border(
+                    width = 1.dp,
+                    color = LGTMTheme.colors.gray_2,
+                    shape = RoundedCornerShape(10.dp)
+                ),
+            expanded = isExpanded,
+            onDismissRequest = onDismissRequest
+        ) {
+            DropdownMenuItem(
+                onClick = onMenuClick
+            ) {
+                Text(
+                    text = text,
+                    style = LGTMTheme.typography.body2,
+                    color = LGTMTheme.colors.black
+                )
+            }
+        }
+    }
+}

--- a/common-ui/src/main/java/com/lgtm/android/common_ui/components/dropdown/SuggestionDropDownOneMenu.kt
+++ b/common-ui/src/main/java/com/lgtm/android/common_ui/components/dropdown/SuggestionDropDownOneMenu.kt
@@ -34,7 +34,10 @@ fun SuggestionDropDownOneMenu(
             onDismissRequest = onDismissRequest
         ) {
             DropdownMenuItem(
-                onClick = onMenuClick
+                onClick = {
+                    onDismissRequest()
+                    onMenuClick()
+                }
             ) {
                 Text(
                     text = text,

--- a/common-ui/src/main/res/values/strings.xml
+++ b/common-ui/src/main/res/values/strings.xml
@@ -154,6 +154,10 @@
     
     <!-- 미션 제안 디테일  -->
     <string name="want_this_mission">저도 이 미션 원해요!</string>
+    <string name="delete_suggestion">삭제하기</string>
+    <string name="report_suggestion">신고하기</string>
+    <string name="want_to_delete_suggestion">게시글을 삭제하시겠어요?</string>
+    <string name="cannot_cancel_the_deletion">삭제 후에는 되돌릴 수 없어요.</string>
 
     <!-- 미션 제안 생성  -->
     <string name="mission_suggestion_title">제목</string>

--- a/data/src/main/java/com/lgtm/android/data/datasource/SuggestionDataSource.kt
+++ b/data/src/main/java/com/lgtm/android/data/datasource/SuggestionDataSource.kt
@@ -4,6 +4,7 @@ import com.lgtm.android.data.model.response.BaseDTO
 import com.lgtm.android.data.model.response.CreateSuggestionResponseDTO
 import com.lgtm.android.data.model.response.MissionSuggestionDTO
 import com.lgtm.android.data.model.response.SuggestionDTO
+import com.lgtm.android.data.model.response.SuggestionLikeDTO
 import com.lgtm.android.data.service.SuggestionService
 import com.lgtm.domain.entity.request.CreateSuggestionRequestVO
 import javax.inject.Inject
@@ -21,5 +22,13 @@ class SuggestionDataSource @Inject constructor(
 
     suspend fun createSuggestion(createSuggestionRequest: CreateSuggestionRequestVO): BaseDTO<CreateSuggestionResponseDTO> {
         return checkResponse(suggestionService.createSuggestion(createSuggestionRequest))
+    }
+
+    suspend fun likeSuggestion(suggestionId: Int): BaseDTO<SuggestionLikeDTO> {
+        return checkResponse(suggestionService.likeSuggestion(suggestionId))
+    }
+
+    suspend fun cancelLikeSuggestion(suggestionId: Int): BaseDTO<SuggestionLikeDTO> {
+        return checkResponse(suggestionService.cancelLikeSuggestion(suggestionId))
     }
 }

--- a/data/src/main/java/com/lgtm/android/data/datasource/SuggestionDataSource.kt
+++ b/data/src/main/java/com/lgtm/android/data/datasource/SuggestionDataSource.kt
@@ -2,6 +2,7 @@ package com.lgtm.android.data.datasource
 
 import com.lgtm.android.data.model.response.BaseDTO
 import com.lgtm.android.data.model.response.CreateSuggestionResponseDTO
+import com.lgtm.android.data.model.response.DeleteSuggestionDTO
 import com.lgtm.android.data.model.response.MissionSuggestionDTO
 import com.lgtm.android.data.model.response.SuggestionDTO
 import com.lgtm.android.data.model.response.SuggestionLikeDTO
@@ -30,5 +31,9 @@ class SuggestionDataSource @Inject constructor(
 
     suspend fun cancelLikeSuggestion(suggestionId: Int): BaseDTO<SuggestionLikeDTO> {
         return checkResponse(suggestionService.cancelLikeSuggestion(suggestionId))
+    }
+
+    suspend fun deleteSuggestion(suggestionId: Int): BaseDTO<DeleteSuggestionDTO> {
+        return checkResponse(suggestionService.deleteSuggestion(suggestionId))
     }
 }

--- a/data/src/main/java/com/lgtm/android/data/model/response/DeleteSuggestionDTO.kt
+++ b/data/src/main/java/com/lgtm/android/data/model/response/DeleteSuggestionDTO.kt
@@ -1,0 +1,13 @@
+package com.lgtm.android.data.model.response
+
+import com.lgtm.domain.entity.response.DeleteSuggestionVO
+
+data class DeleteSuggestionDTO(
+    val suggestionId: Int?,
+    val success: Boolean?
+) {
+    fun toVO() = DeleteSuggestionVO(
+        suggestionId = suggestionId ?: 0,
+        success = success ?: false
+    )
+}

--- a/data/src/main/java/com/lgtm/android/data/model/response/SuggestionLikeDTO.kt
+++ b/data/src/main/java/com/lgtm/android/data/model/response/SuggestionLikeDTO.kt
@@ -1,0 +1,13 @@
+package com.lgtm.android.data.model.response
+
+import com.lgtm.domain.entity.response.SuggestionLikeVO
+
+data class SuggestionLikeDTO(
+    val isLiked: Boolean?,
+    val likeNum: String?
+) {
+    fun toVO() = SuggestionLikeVO(
+        isLiked = requireNotNull(isLiked),
+        likeNum = requireNotNull(likeNum)
+    )
+}

--- a/data/src/main/java/com/lgtm/android/data/repository/SuggestionRepositoryImpl.kt
+++ b/data/src/main/java/com/lgtm/android/data/repository/SuggestionRepositoryImpl.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.lgtm.android.data.datasource.SuggestionDataSource
 import com.lgtm.domain.entity.request.CreateSuggestionRequestVO
 import com.lgtm.domain.entity.response.CreateSuggestionResponseVO
+import com.lgtm.domain.entity.response.DeleteSuggestionVO
 import com.lgtm.domain.entity.response.SuggestionLikeVO
 import com.lgtm.domain.mission_suggestion.MissionSuggestionVO
 import com.lgtm.domain.mission_suggestion.SuggestionVO
@@ -60,6 +61,16 @@ class SuggestionRepositoryImpl @Inject constructor(
             Result.success(response.data.toVO())
         } catch (e: Exception) {
             Log.e(TAG, "cancelLikeSuggestion: ${this.javaClass} ${e.message}")
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun deleteSuggestion(suggestionId: Int): Result<DeleteSuggestionVO> {
+        return try {
+            val response = suggestionDataSource.deleteSuggestion(suggestionId)
+            Result.success(response.data.toVO())
+        } catch (e: Exception) {
+            Log.e(TAG, "deleteSuggestion: ${this.javaClass} ${e.message}")
             Result.failure(e)
         }
     }

--- a/data/src/main/java/com/lgtm/android/data/repository/SuggestionRepositoryImpl.kt
+++ b/data/src/main/java/com/lgtm/android/data/repository/SuggestionRepositoryImpl.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.lgtm.android.data.datasource.SuggestionDataSource
 import com.lgtm.domain.entity.request.CreateSuggestionRequestVO
 import com.lgtm.domain.entity.response.CreateSuggestionResponseVO
+import com.lgtm.domain.entity.response.SuggestionLikeVO
 import com.lgtm.domain.mission_suggestion.MissionSuggestionVO
 import com.lgtm.domain.mission_suggestion.SuggestionVO
 import com.lgtm.domain.repository.SuggestionRepository
@@ -39,6 +40,26 @@ class SuggestionRepositoryImpl @Inject constructor(
             Result.success(response.data.toVO())
         } catch (e: Exception) {
             Log.e(TAG, "createSuggestion: ${this.javaClass} ${e.message}")
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun likeSuggestion(suggestionId: Int): Result<SuggestionLikeVO> {
+        return try {
+            val response = suggestionDataSource.likeSuggestion(suggestionId)
+            Result.success(response.data.toVO())
+        } catch (e: Exception) {
+            Log.e(TAG, "likeSuggestion: ${this.javaClass} ${e.message}")
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun cancelLikeSuggestion(suggestionId: Int): Result<SuggestionLikeVO> {
+        return try {
+            val response = suggestionDataSource.cancelLikeSuggestion(suggestionId)
+            Result.success(response.data.toVO())
+        } catch (e: Exception) {
+            Log.e(TAG, "cancelLikeSuggestion: ${this.javaClass} ${e.message}")
             Result.failure(e)
         }
     }

--- a/data/src/main/java/com/lgtm/android/data/service/SuggestionService.kt
+++ b/data/src/main/java/com/lgtm/android/data/service/SuggestionService.kt
@@ -2,6 +2,7 @@ package com.lgtm.android.data.service
 
 import com.lgtm.android.data.model.response.BaseDTO
 import com.lgtm.android.data.model.response.CreateSuggestionResponseDTO
+import com.lgtm.android.data.model.response.DeleteSuggestionDTO
 import com.lgtm.android.data.model.response.MissionSuggestionDTO
 import com.lgtm.android.data.model.response.SuggestionDTO
 import com.lgtm.android.data.model.response.SuggestionLikeDTO
@@ -37,4 +38,8 @@ interface SuggestionService {
         @Path("suggestionId") suggestionId: Int
     ): Response<BaseDTO<SuggestionLikeDTO>>
 
+    @DELETE("v1/suggestion/{suggestionId}")
+    suspend fun deleteSuggestion(
+        @Path("suggestionId") suggestionId: Int
+    ): Response<BaseDTO<DeleteSuggestionDTO>>
 }

--- a/data/src/main/java/com/lgtm/android/data/service/SuggestionService.kt
+++ b/data/src/main/java/com/lgtm/android/data/service/SuggestionService.kt
@@ -4,9 +4,11 @@ import com.lgtm.android.data.model.response.BaseDTO
 import com.lgtm.android.data.model.response.CreateSuggestionResponseDTO
 import com.lgtm.android.data.model.response.MissionSuggestionDTO
 import com.lgtm.android.data.model.response.SuggestionDTO
+import com.lgtm.android.data.model.response.SuggestionLikeDTO
 import com.lgtm.domain.entity.request.CreateSuggestionRequestVO
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -24,4 +26,15 @@ interface SuggestionService {
     suspend fun createSuggestion(
         @Body createSuggestionRequestVO: CreateSuggestionRequestVO
     ): Response<BaseDTO<CreateSuggestionResponseDTO>>
+
+    @POST("v1/suggestion/{suggestionId}/like")
+    suspend fun likeSuggestion(
+        @Path("suggestionId") suggestionId: Int
+    ): Response<BaseDTO<SuggestionLikeDTO>>
+
+    @DELETE("v1/suggestion/{suggestionId}/like")
+    suspend fun cancelLikeSuggestion(
+        @Path("suggestionId") suggestionId: Int
+    ): Response<BaseDTO<SuggestionLikeDTO>>
+
 }

--- a/domain/src/main/java/com/lgtm/domain/entity/response/DeleteSuggestionVO.kt
+++ b/domain/src/main/java/com/lgtm/domain/entity/response/DeleteSuggestionVO.kt
@@ -1,0 +1,6 @@
+package com.lgtm.domain.entity.response
+
+data class DeleteSuggestionVO(
+    val suggestionId: Int,
+    val success: Boolean
+)

--- a/domain/src/main/java/com/lgtm/domain/entity/response/SuggestionLikeVO.kt
+++ b/domain/src/main/java/com/lgtm/domain/entity/response/SuggestionLikeVO.kt
@@ -1,0 +1,6 @@
+package com.lgtm.domain.entity.response
+
+data class SuggestionLikeVO(
+    val isLiked: Boolean,
+    val likeNum: String
+)

--- a/domain/src/main/java/com/lgtm/domain/repository/SuggestionRepository.kt
+++ b/domain/src/main/java/com/lgtm/domain/repository/SuggestionRepository.kt
@@ -2,6 +2,7 @@ package com.lgtm.domain.repository
 
 import com.lgtm.domain.entity.request.CreateSuggestionRequestVO
 import com.lgtm.domain.entity.response.CreateSuggestionResponseVO
+import com.lgtm.domain.entity.response.DeleteSuggestionVO
 import com.lgtm.domain.entity.response.SuggestionLikeVO
 import com.lgtm.domain.mission_suggestion.MissionSuggestionVO
 import com.lgtm.domain.mission_suggestion.SuggestionVO
@@ -12,4 +13,5 @@ interface SuggestionRepository {
     suspend fun createSuggestion(createSuggestionRequest: CreateSuggestionRequestVO): Result<CreateSuggestionResponseVO>
     suspend fun likeSuggestion(suggestionId: Int): Result<SuggestionLikeVO>
     suspend fun cancelLikeSuggestion(suggestionId: Int): Result<SuggestionLikeVO>
+    suspend fun deleteSuggestion(suggestionId: Int): Result<DeleteSuggestionVO>
 }

--- a/domain/src/main/java/com/lgtm/domain/repository/SuggestionRepository.kt
+++ b/domain/src/main/java/com/lgtm/domain/repository/SuggestionRepository.kt
@@ -2,6 +2,7 @@ package com.lgtm.domain.repository
 
 import com.lgtm.domain.entity.request.CreateSuggestionRequestVO
 import com.lgtm.domain.entity.response.CreateSuggestionResponseVO
+import com.lgtm.domain.entity.response.SuggestionLikeVO
 import com.lgtm.domain.mission_suggestion.MissionSuggestionVO
 import com.lgtm.domain.mission_suggestion.SuggestionVO
 
@@ -9,4 +10,6 @@ interface SuggestionRepository {
     suspend fun getSuggestion(): Result<MissionSuggestionVO>
     suspend fun getSuggestionDetail(suggestionId: Int): Result<SuggestionVO>
     suspend fun createSuggestion(createSuggestionRequest: CreateSuggestionRequestVO): Result<CreateSuggestionResponseVO>
+    suspend fun likeSuggestion(suggestionId: Int): Result<SuggestionLikeVO>
+    suspend fun cancelLikeSuggestion(suggestionId: Int): Result<SuggestionLikeVO>
 }

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/create_suggestion/presentation/CreateSuggestionScreen.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/create_suggestion/presentation/CreateSuggestionScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Text
 import androidx.compose.material.rememberModalBottomSheetState
@@ -63,31 +62,12 @@ fun CreateSuggestionScreen(
     val suggestionContentTextData by viewModel.suggestionContentTextData.collectAsStateWithLifecycle()
     val isSuggestionValid by viewModel.isSuggestionValid.collectAsStateWithLifecycle()
 
-    ModalBottomSheetLayout(
-        sheetState = bottomSheetState,
-        sheetShape = RoundedCornerShape(
-            topStart = 20.dp,
-            topEnd = 20.dp
-        ),
-        scrimColor = LGTMTheme.colors.transparent_black,
-        sheetContent = {
-            LgtmConfirmationDialog(
-                dialogTitle = stringResource(id = R.string.want_to_stop_creating_suggestion),
-                dialogDescription = stringResource(id = R.string.content_will_not_be_saved),
-                onClickCancel = {
-                    coroutineScope.launch {
-                        bottomSheetState.hide()
-                    }
-                },
-                onClickConfirm = {
-                    coroutineScope.launch {
-                        bottomSheetState.hide()
-                        onBackButtonClick()
-                    }
-                },
-                confirmBtnBackground = ConfirmButtonBackgroundColor.GRAY
-            )
-        }
+    LgtmConfirmationDialog(
+        bottomSheetState = bottomSheetState,
+        dialogTitle = stringResource(id = R.string.want_to_stop_creating_suggestion),
+        dialogDescription = stringResource(id = R.string.content_will_not_be_saved),
+        onClickConfirm = onBackButtonClick,
+        confirmBtnBackground = ConfirmButtonBackgroundColor.GRAY
     ) {
         ConstraintLayout(
             modifier = Modifier

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailActivity.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailActivity.kt
@@ -7,10 +7,15 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.lgtm.android.common_ui.base.BaseComposeActivity
 import com.lgtm.android.common_ui.theme.LGTMTheme
 import com.lgtm.android.mission_suggestion.ui.detail.presentation.SuggestionDetailScreen
+import com.lgtm.android.mission_suggestion.ui.detail.presentation.contract.SuggestionDetailUiEffect
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class SuggestionDetailActivity: BaseComposeActivity(){
@@ -24,22 +29,38 @@ class SuggestionDetailActivity: BaseComposeActivity(){
     @Composable
     override fun Content() {
         LGTMTheme {
-            SuggestionDetailScreen(
-                onBackButtonClick = ::setBackButtonClick,
-                onReportSuggestionClick = ::setReportSuggestionClick
-            )
+            SuggestionDetailScreen()
         }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        observeUiEffect()
         fetchSuggestionDetail()
     }
     private fun fetchSuggestionDetail() {
         suggestionDetailViewModel.fetchDetail(suggestionId)
     }
 
-    private fun setBackButtonClick() {
+    private fun observeUiEffect() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                suggestionDetailViewModel.detailUiEffect.collect { effect ->
+                    when (effect) {
+                        is SuggestionDetailUiEffect.SendEmail -> {
+                            setReportSuggestionClick()
+                        }
+
+                        is SuggestionDetailUiEffect.GoBack -> {
+                            goBack()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun goBack() {
         finish()
     }
 

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailActivity.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailActivity.kt
@@ -1,6 +1,10 @@
 package com.lgtm.android.mission_suggestion.ui.detail
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
 import com.lgtm.android.common_ui.base.BaseComposeActivity
@@ -21,7 +25,8 @@ class SuggestionDetailActivity: BaseComposeActivity(){
     override fun Content() {
         LGTMTheme {
             SuggestionDetailScreen(
-                onBackButtonClick = ::setBackButtonClick
+                onBackButtonClick = ::setBackButtonClick,
+                onReportSuggestionClick = ::setReportSuggestionClick
             )
         }
     }
@@ -36,6 +41,20 @@ class SuggestionDetailActivity: BaseComposeActivity(){
 
     private fun setBackButtonClick() {
         finish()
+    }
+
+    private fun setReportSuggestionClick() {
+        val intent = Intent(Intent.ACTION_SENDTO).apply {
+            data = Uri.parse("mailto:")
+            putExtra(Intent.EXTRA_EMAIL, arrayOf("hkcc.swm.official@gmail.com"))
+            putExtra(Intent.EXTRA_SUBJECT, "[LGTM] 미션 제안 불편사항 신고")
+            putExtra(Intent.EXTRA_TEXT, suggestionDetailViewModel.getReportMessage())
+        }
+        try {
+            startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            Toast.makeText(this, "메일을 보낼 수 없습니다", Toast.LENGTH_SHORT).show()
+        }
     }
 
     companion object {

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailActivity.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailActivity.kt
@@ -3,7 +3,6 @@ package com.lgtm.android.mission_suggestion.ui.detail
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lgtm.android.common_ui.base.BaseComposeActivity
 import com.lgtm.android.common_ui.theme.LGTMTheme
 import com.lgtm.android.mission_suggestion.ui.detail.presentation.SuggestionDetailScreen
@@ -22,7 +21,6 @@ class SuggestionDetailActivity: BaseComposeActivity(){
     override fun Content() {
         LGTMTheme {
             SuggestionDetailScreen(
-                suggestionDetailStateHolder = suggestionDetailViewModel.detailState.collectAsStateWithLifecycle(),
                 onBackButtonClick = ::setBackButtonClick
             )
         }

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailActivity.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailActivity.kt
@@ -22,7 +22,8 @@ class SuggestionDetailActivity: BaseComposeActivity(){
     override fun Content() {
         LGTMTheme {
             SuggestionDetailScreen(
-                suggestionDetailStateHolder = suggestionDetailViewModel.detailState.collectAsStateWithLifecycle()
+                suggestionDetailStateHolder = suggestionDetailViewModel.detailState.collectAsStateWithLifecycle(),
+                onBackButtonClick = ::setBackButtonClick
             )
         }
     }
@@ -33,6 +34,10 @@ class SuggestionDetailActivity: BaseComposeActivity(){
     }
     private fun fetchSuggestionDetail() {
         suggestionDetailViewModel.fetchDetail(suggestionId)
+    }
+
+    private fun setBackButtonClick() {
+        finish()
     }
 
     companion object {

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailViewModel.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailViewModel.kt
@@ -10,6 +10,7 @@ import com.lgtm.android.common_ui.model.SuggestionUI
 import com.lgtm.android.common_ui.model.mapper.toUiModel
 import com.lgtm.android.common_ui.util.UiState
 import com.lgtm.domain.entity.response.SuggestionLikeVO
+import com.lgtm.domain.repository.AuthRepository
 import com.lgtm.domain.repository.SuggestionRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,7 +20,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SuggestionDetailViewModel @Inject constructor(
-    private val suggestionRepository: SuggestionRepository
+    private val suggestionRepository: SuggestionRepository,
+    private val authRepository: AuthRepository
 ): BaseViewModel() {
 
     /* 미션 제안 상세 내용 */
@@ -94,6 +96,42 @@ class SuggestionDetailViewModel @Inject constructor(
                     Firebase.crashlytics.recordException(it)
                     Log.e(TAG, "deleteSuggestion: $it")
                 }
+        }
+    }
+
+    /* 미션 제안 신고 기능 */
+    fun getReportMessage() =
+        "안녕하세요 고객님, LGTM 서비스 이용에 불편을 드려 죄송합니다. 보내주신 내용은 빠른 시일 내로 운영팀에서 처리하겠습니다.\n" +
+                "처리 결과는 발신된 이메일 주소로 전달될 예정입니다. 감사합니다.\n\n" +
+                "[신고 유형을 선택해주세요]\n" +
+                "1. 성적, 폭력적 또는 혐오스러운 내용\n" +
+                "2. 욕설 혹은 유해한 내용\n" +
+                "3. 기타 부적절한 내용\n" +
+                "4. 기타 서비스 이용 불편사항\n" +
+                "응답 : \n" +
+                "\n\n\n" +
+                "[신고 내용]\n" +
+                "불편을 겪으신 내용을 적어주세요. 필요시 사진을 첨부해주셔도 좋습니다.\n" +
+                "응답 : \n" +
+                "\n\n\n" +
+                "-------------------------------------------------\n" +
+                "아래 내용은 운영진에게 전달되는 정보니 수정하지 말아주세요:)\n\n" +
+                "[신고 정보]\n" +
+                "1. 신고자 ID : ${getUserId()}\n" +
+                "2. 미션 제안 제목 : ${getMissionTitle()}\n" +
+                "3. 미션 제안 본문 : ${getMissionDescription()} \n"
+
+    private fun getUserId() = authRepository.getMemberId()
+
+    private fun getMissionTitle(): String {
+        detailState.value.apply {
+            return if (this is UiState.Success) this.data.title else ""
+        }
+    }
+
+    private fun getMissionDescription(): String {
+        detailState.value.apply {
+            return if (this is UiState.Success) this.data.description else ""
         }
     }
 }

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailViewModel.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailViewModel.kt
@@ -81,4 +81,19 @@ class SuggestionDetailViewModel @Inject constructor(
                 }
         }
     }
+
+    /* 미션 제안 삭제 기능 */
+
+    fun deleteSuggestion() {
+        viewModelScope.launch(lgtmErrorHandler) {
+            suggestionRepository.deleteSuggestion(getSuggestionId())
+                .onSuccess {
+                    Log.d(TAG, "deletedSuggestion: $it")
+                }
+                .onFailure {
+                    Firebase.crashlytics.recordException(it)
+                    Log.e(TAG, "deleteSuggestion: $it")
+                }
+        }
+    }
 }

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailViewModel.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailViewModel.kt
@@ -9,6 +9,7 @@ import com.lgtm.android.common_ui.base.BaseViewModel
 import com.lgtm.android.common_ui.model.SuggestionUI
 import com.lgtm.android.common_ui.model.mapper.toUiModel
 import com.lgtm.android.common_ui.util.UiState
+import com.lgtm.domain.entity.response.SuggestionLikeVO
 import com.lgtm.domain.repository.SuggestionRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,10 +21,16 @@ import javax.inject.Inject
 class SuggestionDetailViewModel @Inject constructor(
     private val suggestionRepository: SuggestionRepository
 ): BaseViewModel() {
+
+    /* 미션 제안 상세 내용 */
     private val _detailState: MutableStateFlow<UiState<SuggestionUI>> = MutableStateFlow(
         UiState.Init)
     val detailState: StateFlow<UiState<SuggestionUI>>
         get() = _detailState
+
+    private val _likeSuggestionState: MutableStateFlow<UiState<SuggestionLikeVO>> = MutableStateFlow(UiState.Init)
+    val likeSuggestionState: StateFlow<UiState<SuggestionLikeVO>>
+        get() = _likeSuggestionState
 
     fun fetchDetail(id: Int) {
         viewModelScope.launch(lgtmErrorHandler) {
@@ -31,16 +38,46 @@ class SuggestionDetailViewModel @Inject constructor(
 
             suggestionRepository.getSuggestionDetail(id)
                 .onSuccess {
-                    _detailState.value = UiState.Success(
-                        data = it.toUiModel()
-                    )
+                    _detailState.value = UiState.Success(data = it.toUiModel())
+                    _likeSuggestionState.value = UiState.Success(data = createSuggestionLikeVO(it.isLiked, it.likeNum))
                     Log.d(TAG, "getSuggestionDetail: $it")
                 }.onFailure {
-                    _detailState.value = UiState.Failure(
-                        msg = it.message
-                    )
+                    _detailState.value = UiState.Failure(msg = it.message)
                     Firebase.crashlytics.recordException(it)
                     Log.e(TAG, "getSuggestionDetail: $it")
+                }
+        }
+    }
+
+    private fun createSuggestionLikeVO(isLiked: Boolean, likeNum: String) = SuggestionLikeVO(isLiked, likeNum)
+
+    /* 미션 제안 좋아요 기능 */
+    private fun getSuggestionId(): Int = if (detailState.value is UiState.Success) (detailState.value as UiState.Success<SuggestionUI>).data.suggestionId else -1
+
+    fun likeSuggestion() {
+        viewModelScope.launch(lgtmErrorHandler) {
+            suggestionRepository.likeSuggestion(getSuggestionId())
+                .onSuccess {
+                    _likeSuggestionState.value = UiState.Success(data = it)
+                    Log.d(TAG, "likeSuggestion: $it")
+                }.onFailure {
+                    _likeSuggestionState.value = UiState.Failure(msg = it.message)
+                    Firebase.crashlytics.recordException(it)
+                    Log.e(TAG, "likeSuggestion: $it")
+                }
+        }
+    }
+
+    fun cancelLikeSuggestion() {
+        viewModelScope.launch(lgtmErrorHandler) {
+            suggestionRepository.cancelLikeSuggestion(getSuggestionId())
+                .onSuccess {
+                    _likeSuggestionState.value = UiState.Success(data = it)
+                    Log.d(TAG, "cancelLikeSuggestion: $it")
+                }.onFailure {
+                    _likeSuggestionState.value = UiState.Failure(msg = it.message)
+                    Firebase.crashlytics.recordException(it)
+                    Log.e(TAG, "cancelLikeSuggestion: $it")
                 }
         }
     }

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailViewModel.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/SuggestionDetailViewModel.kt
@@ -9,7 +9,6 @@ import com.lgtm.android.common_ui.base.BaseViewModel
 import com.lgtm.android.common_ui.model.SuggestionUI
 import com.lgtm.android.common_ui.model.mapper.toUiModel
 import com.lgtm.android.common_ui.util.UiState
-import com.lgtm.domain.entity.response.SuggestionLikeVO
 import com.lgtm.domain.repository.AuthRepository
 import com.lgtm.domain.repository.SuggestionRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -25,23 +24,16 @@ class SuggestionDetailViewModel @Inject constructor(
 ): BaseViewModel() {
 
     /* 미션 제안 상세 내용 */
-    private val _detailState: MutableStateFlow<UiState<SuggestionUI>> = MutableStateFlow(
-        UiState.Init)
+    private val _detailState: MutableStateFlow<UiState<SuggestionUI>> = MutableStateFlow(UiState.Init)
     val detailState: StateFlow<UiState<SuggestionUI>>
         get() = _detailState
-
-    private val _likeSuggestionState: MutableStateFlow<UiState<SuggestionLikeVO>> = MutableStateFlow(UiState.Init)
-    val likeSuggestionState: StateFlow<UiState<SuggestionLikeVO>>
-        get() = _likeSuggestionState
 
     fun fetchDetail(id: Int) {
         viewModelScope.launch(lgtmErrorHandler) {
             _detailState.value = UiState.Init
-
             suggestionRepository.getSuggestionDetail(id)
                 .onSuccess {
                     _detailState.value = UiState.Success(data = it.toUiModel())
-                    _likeSuggestionState.value = UiState.Success(data = createSuggestionLikeVO(it.isLiked, it.likeNum))
                     Log.d(TAG, "getSuggestionDetail: $it")
                 }.onFailure {
                     _detailState.value = UiState.Failure(msg = it.message)
@@ -51,8 +43,6 @@ class SuggestionDetailViewModel @Inject constructor(
         }
     }
 
-    private fun createSuggestionLikeVO(isLiked: Boolean, likeNum: String) = SuggestionLikeVO(isLiked, likeNum)
-
     /* 미션 제안 좋아요 기능 */
     private fun getSuggestionId(): Int = if (detailState.value is UiState.Success) (detailState.value as UiState.Success<SuggestionUI>).data.suggestionId else -1
 
@@ -60,10 +50,10 @@ class SuggestionDetailViewModel @Inject constructor(
         viewModelScope.launch(lgtmErrorHandler) {
             suggestionRepository.likeSuggestion(getSuggestionId())
                 .onSuccess {
-                    _likeSuggestionState.value = UiState.Success(data = it)
+                    updateLikeState(it.likeNum, it.isLiked)
                     Log.d(TAG, "likeSuggestion: $it")
                 }.onFailure {
-                    _likeSuggestionState.value = UiState.Failure(msg = it.message)
+                    _detailState.value = UiState.Failure(msg = it.message)
                     Firebase.crashlytics.recordException(it)
                     Log.e(TAG, "likeSuggestion: $it")
                 }
@@ -74,13 +64,23 @@ class SuggestionDetailViewModel @Inject constructor(
         viewModelScope.launch(lgtmErrorHandler) {
             suggestionRepository.cancelLikeSuggestion(getSuggestionId())
                 .onSuccess {
-                    _likeSuggestionState.value = UiState.Success(data = it)
+                    updateLikeState(it.likeNum, it.isLiked)
                     Log.d(TAG, "cancelLikeSuggestion: $it")
                 }.onFailure {
-                    _likeSuggestionState.value = UiState.Failure(msg = it.message)
+                    _detailState.value = UiState.Failure(msg = it.message)
                     Firebase.crashlytics.recordException(it)
                     Log.e(TAG, "cancelLikeSuggestion: $it")
                 }
+        }
+    }
+
+    private fun updateLikeState(likeNum: String, isLiked: Boolean) {
+        if (detailState.value is UiState.Success) {
+            val suggestion = (detailState.value as UiState.Success<SuggestionUI>).data.copy(
+                likeNum = likeNum,
+                isLiked = isLiked
+            )
+            _detailState.value = UiState.Success(data = suggestion)
         }
     }
 

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/SuggestionDetailScreen.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/SuggestionDetailScreen.kt
@@ -39,9 +39,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun SuggestionDetailScreen(
-    viewModel: SuggestionDetailViewModel = hiltViewModel(),
-    onBackButtonClick: () -> Unit,
-    onReportSuggestionClick: () -> Unit
+    viewModel: SuggestionDetailViewModel = hiltViewModel()
 ) {
     val suggestionDetailState: UiState<SuggestionUI> by viewModel.detailState.collectAsStateWithLifecycle()
     val bottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)
@@ -50,14 +48,13 @@ fun SuggestionDetailScreen(
     when(suggestionDetailState) {
         is UiState.Init -> { /* no-op */ }
         is UiState.Success -> {
-            val suggestionDetailState = suggestionDetailState as UiState.Success<SuggestionUI>
+            val suggestionDetailState = suggestionDetailState as UiState.Success
             LgtmConfirmationDialog(
                 bottomSheetState = bottomSheetState,
                 dialogTitle = stringResource(id = R.string.want_to_delete_suggestion),
                 dialogDescription = stringResource(id = R.string.cannot_cancel_the_deletion),
                 onClickConfirm = {
                     viewModel.deleteSuggestion()
-                    onBackButtonClick()
                 },
                 confirmBtnBackground = ConfirmButtonBackgroundColor.GRAY
             ) {
@@ -74,8 +71,8 @@ fun SuggestionDetailScreen(
                                 bottomSheetState.show()
                             }
                         },
-                        onReportSuggestion = onReportSuggestionClick,
-                        onBackButtonClick = onBackButtonClick,
+                        onReportSuggestion = viewModel::reportSuggestion,
+                        onBackButtonClick = viewModel::goBack,
                     )
                     SuggestionLikeSection(
                         modifier = Modifier.padding(vertical = 5.dp),

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/SuggestionDetailScreen.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/SuggestionDetailScreen.kt
@@ -27,7 +27,8 @@ import com.lgtm.android.common_ui.util.UiState
 
 @Composable
 fun SuggestionDetailScreen(
-    suggestionDetailStateHolder: State<UiState<SuggestionUI>>
+    suggestionDetailStateHolder: State<UiState<SuggestionUI>>,
+    onBackButtonClick: () -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -35,9 +36,9 @@ fun SuggestionDetailScreen(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         SuggestionDetailContent(
-            modifier = Modifier
-                .weight(1f),
-            suggestionDetailState = suggestionDetailStateHolder.value
+            modifier = Modifier.weight(1f),
+            suggestionDetailState = suggestionDetailStateHolder.value,
+            onBackButtonClick = onBackButtonClick
         )
         SuggestionLikeSection(
             modifier = Modifier.padding(vertical = 5.dp),
@@ -49,12 +50,11 @@ fun SuggestionDetailScreen(
 @Composable
 fun SuggestionDetailContent(
     modifier: Modifier = Modifier,
-    suggestionDetailState: UiState<SuggestionUI>
+    suggestionDetailState: UiState<SuggestionUI>,
+    onBackButtonClick: () -> Unit
 ) {
     when (suggestionDetailState) {
-        is UiState.Init -> {
-            /* no-op */
-        }
+        is UiState.Init -> { /* no-op */ }
         is UiState.Success -> {
             Column(
                 modifier = modifier
@@ -67,7 +67,7 @@ fun SuggestionDetailContent(
                         )
                     )
             ) {
-                SuggestionDetailTopBar()
+                SuggestionDetailTopBar(onBackButtonClick)
 
                 Text(
                     modifier = Modifier.padding(horizontal = 20.dp),
@@ -104,9 +104,7 @@ fun SuggestionDetailContent(
             }
         }
 
-        else -> {
-            /* no-op */
-        }
+        else -> { /* no-op */ }
     }
 }
 
@@ -116,9 +114,7 @@ fun SuggestionLikeSection(
     suggestionDetailState: UiState<SuggestionUI>
 ) {
     when(suggestionDetailState) {
-        is UiState.Init -> {
-            /* no-op */
-        }
+        is UiState.Init -> { /* no-op */ }
         is UiState.Success -> {
             Row (
                 modifier = modifier
@@ -146,15 +142,14 @@ fun SuggestionLikeSection(
                 )
             }
         }
-
-        else -> {
-            /* no-op */
-        }
+        else -> { /* no-op */ }
     }
 }
 
 @Composable
-fun SuggestionDetailTopBar() {
+fun SuggestionDetailTopBar(
+    onBackButtonClick: () -> Unit
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -165,7 +160,7 @@ fun SuggestionDetailTopBar() {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        BackButton { /* TODO */ }
+        BackButton(onClick = onBackButtonClick)
         MenuButton()
     }
 }

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/SuggestionDetailScreen.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/SuggestionDetailScreen.kt
@@ -54,6 +54,7 @@ fun SuggestionDetailScreen(
         dialogTitle = stringResource(id = R.string.want_to_delete_suggestion),
         dialogDescription = stringResource(id = R.string.cannot_cancel_the_deletion),
         onClickConfirm = {
+            viewModel.deleteSuggestion()
             onBackButtonClick()
         },
         confirmBtnBackground = ConfirmButtonBackgroundColor.GRAY

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/SuggestionDetailScreen.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/SuggestionDetailScreen.kt
@@ -8,9 +8,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Text
+import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -20,15 +24,20 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lgtm.android.common_ui.R
 import com.lgtm.android.common_ui.components.buttons.BackButton
+import com.lgtm.android.common_ui.components.buttons.ConfirmButtonBackgroundColor
 import com.lgtm.android.common_ui.components.buttons.LikeButton
 import com.lgtm.android.common_ui.components.buttons.MenuButton
+import com.lgtm.android.common_ui.components.dialog.LgtmConfirmationDialog
+import com.lgtm.android.common_ui.components.dropdown.SuggestionDropDownOneMenu
 import com.lgtm.android.common_ui.components.texts.DateTimeText
 import com.lgtm.android.common_ui.model.SuggestionUI
 import com.lgtm.android.common_ui.theme.LGTMTheme
 import com.lgtm.android.common_ui.util.UiState
 import com.lgtm.android.mission_suggestion.ui.detail.SuggestionDetailViewModel
 import com.lgtm.domain.entity.response.SuggestionLikeVO
+import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun SuggestionDetailScreen(
     viewModel: SuggestionDetailViewModel = hiltViewModel(),
@@ -37,22 +46,41 @@ fun SuggestionDetailScreen(
     val suggestionDetailState by viewModel.detailState.collectAsStateWithLifecycle()
     val likeSuggestionState by viewModel.likeSuggestionState.collectAsStateWithLifecycle()
 
-    Column(
-        modifier = Modifier
-            .background(LGTMTheme.colors.gray_3),
-        horizontalAlignment = Alignment.CenterHorizontally
+    val bottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)
+    val coroutineScope = rememberCoroutineScope()
+
+    LgtmConfirmationDialog(
+        bottomSheetState = bottomSheetState,
+        dialogTitle = stringResource(id = R.string.want_to_delete_suggestion),
+        dialogDescription = stringResource(id = R.string.cannot_cancel_the_deletion),
+        onClickConfirm = {
+            onBackButtonClick()
+        },
+        confirmBtnBackground = ConfirmButtonBackgroundColor.GRAY
     ) {
-        SuggestionDetailContent(
-            modifier = Modifier.weight(1f),
-            suggestionDetailState = suggestionDetailState,
-            onBackButtonClick = onBackButtonClick
-        )
-        SuggestionLikeSection(
-            modifier = Modifier.padding(vertical = 5.dp),
-            likeSuggestionState = likeSuggestionState,
-            onLikeButtonClick = viewModel::likeSuggestion,
-            onLikeButtonCancel = viewModel::cancelLikeSuggestion
-        )
+        Column(
+            modifier = Modifier
+                .background(LGTMTheme.colors.gray_3),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            SuggestionDetailContent(
+                modifier = Modifier.weight(1f),
+                suggestionDetailState = suggestionDetailState,
+                onDeleteSuggestion = {
+                    coroutineScope.launch {
+                        bottomSheetState.show()
+                    }
+                },
+                onReportSuggestion = { /* TODO: 신고 진행 */ },
+                onBackButtonClick = onBackButtonClick,
+            )
+            SuggestionLikeSection(
+                modifier = Modifier.padding(vertical = 5.dp),
+                likeSuggestionState = likeSuggestionState,
+                onLikeButtonClick = viewModel::likeSuggestion,
+                onLikeButtonCancel = viewModel::cancelLikeSuggestion
+            )
+        }
     }
 }
 
@@ -60,6 +88,8 @@ fun SuggestionDetailScreen(
 fun SuggestionDetailContent(
     modifier: Modifier = Modifier,
     suggestionDetailState: UiState<SuggestionUI>,
+    onDeleteSuggestion: () -> Unit,
+    onReportSuggestion: () -> Unit,
     onBackButtonClick: () -> Unit
 ) {
     Column(
@@ -73,11 +103,16 @@ fun SuggestionDetailContent(
                 )
             )
     ) {
-        SuggestionDetailTopBar(onBackButtonClick)
-
         when (suggestionDetailState) {
             is UiState.Init -> { /* no-op */ }
             is UiState.Success -> {
+                SuggestionDetailTopBar(
+                    onBackButtonClick = onBackButtonClick,
+                    isMySuggestion = suggestionDetailState.data.isMyPost,
+                    onDeleteSuggestion = onDeleteSuggestion,
+                    onReportSuggestion = onReportSuggestion
+                )
+
                 Text(
                     modifier = Modifier.padding(horizontal = 20.dp),
                     text = suggestionDetailState.data.title,
@@ -159,7 +194,10 @@ fun SuggestionLikeSection(
 
 @Composable
 fun SuggestionDetailTopBar(
-    onBackButtonClick: () -> Unit
+    onBackButtonClick: () -> Unit,
+    isMySuggestion: Boolean,
+    onDeleteSuggestion: () -> Unit,
+    onReportSuggestion: () -> Unit
 ) {
     Row(
         modifier = Modifier
@@ -172,6 +210,13 @@ fun SuggestionDetailTopBar(
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         BackButton(onClick = onBackButtonClick)
-        MenuButton()
+        MenuButton { expanded, onDismissRequest->
+            SuggestionDropDownOneMenu(
+                isExpanded = expanded,
+                text = if (isMySuggestion) stringResource(id = R.string.delete_suggestion) else stringResource(id = R.string.report_suggestion),
+                onDismissRequest = onDismissRequest,
+                onMenuClick = if (isMySuggestion) onDeleteSuggestion else onReportSuggestion
+            )
+        }
     }
 }

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/SuggestionDetailScreen.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/SuggestionDetailScreen.kt
@@ -10,12 +10,14 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lgtm.android.common_ui.R
 import com.lgtm.android.common_ui.components.buttons.BackButton
 import com.lgtm.android.common_ui.components.buttons.LikeButton
@@ -24,12 +26,17 @@ import com.lgtm.android.common_ui.components.texts.DateTimeText
 import com.lgtm.android.common_ui.model.SuggestionUI
 import com.lgtm.android.common_ui.theme.LGTMTheme
 import com.lgtm.android.common_ui.util.UiState
+import com.lgtm.android.mission_suggestion.ui.detail.SuggestionDetailViewModel
+import com.lgtm.domain.entity.response.SuggestionLikeVO
 
 @Composable
 fun SuggestionDetailScreen(
-    suggestionDetailStateHolder: State<UiState<SuggestionUI>>,
+    viewModel: SuggestionDetailViewModel = hiltViewModel(),
     onBackButtonClick: () -> Unit
 ) {
+    val suggestionDetailState by viewModel.detailState.collectAsStateWithLifecycle()
+    val likeSuggestionState by viewModel.likeSuggestionState.collectAsStateWithLifecycle()
+
     Column(
         modifier = Modifier
             .background(LGTMTheme.colors.gray_3),
@@ -37,12 +44,14 @@ fun SuggestionDetailScreen(
     ) {
         SuggestionDetailContent(
             modifier = Modifier.weight(1f),
-            suggestionDetailState = suggestionDetailStateHolder.value,
+            suggestionDetailState = suggestionDetailState,
             onBackButtonClick = onBackButtonClick
         )
         SuggestionLikeSection(
             modifier = Modifier.padding(vertical = 5.dp),
-            suggestionDetailState = suggestionDetailStateHolder.value
+            likeSuggestionState = likeSuggestionState,
+            onLikeButtonClick = viewModel::likeSuggestion,
+            onLikeButtonCancel = viewModel::cancelLikeSuggestion
         )
     }
 }
@@ -53,22 +62,22 @@ fun SuggestionDetailContent(
     suggestionDetailState: UiState<SuggestionUI>,
     onBackButtonClick: () -> Unit
 ) {
-    when (suggestionDetailState) {
-        is UiState.Init -> { /* no-op */ }
-        is UiState.Success -> {
-            Column(
-                modifier = modifier
-                    .fillMaxWidth()
-                    .background(
-                        color = Color.White,
-                        shape = RoundedCornerShape(
-                            bottomStart = 20.dp,
-                            bottomEnd = 20.dp
-                        )
-                    )
-            ) {
-                SuggestionDetailTopBar(onBackButtonClick)
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                color = Color.White,
+                shape = RoundedCornerShape(
+                    bottomStart = 20.dp,
+                    bottomEnd = 20.dp
+                )
+            )
+    ) {
+        SuggestionDetailTopBar(onBackButtonClick)
 
+        when (suggestionDetailState) {
+            is UiState.Init -> { /* no-op */ }
+            is UiState.Success -> {
                 Text(
                     modifier = Modifier.padding(horizontal = 20.dp),
                     text = suggestionDetailState.data.title,
@@ -102,47 +111,49 @@ fun SuggestionDetailContent(
                     color = LGTMTheme.colors.black
                 )
             }
+            else -> { /* no-op */ }
         }
-
-        else -> { /* no-op */ }
     }
 }
 
 @Composable
 fun SuggestionLikeSection(
     modifier: Modifier = Modifier,
-    suggestionDetailState: UiState<SuggestionUI>
+    likeSuggestionState: UiState<SuggestionLikeVO>,
+    onLikeButtonClick: () -> Unit,
+    onLikeButtonCancel: () -> Unit
 ) {
-    when(suggestionDetailState) {
-        is UiState.Init -> { /* no-op */ }
-        is UiState.Success -> {
-            Row (
-                modifier = modifier
-                    .fillMaxWidth()
-                    .background(
-                        color = LGTMTheme.colors.gray_2,
-                        shape = RoundedCornerShape(20.dp)
-                    )
-                    .padding(
-                        horizontal = 20.dp,
-                        vertical = 14.dp
-                    ),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Text(
-                    text = stringResource(id = R.string.want_this_mission),
-                    style = LGTMTheme.typography.body1B,
-                    color = LGTMTheme.colors.gray_6
-                )
-
+    Row (
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                color = LGTMTheme.colors.gray_2,
+                shape = RoundedCornerShape(20.dp)
+            )
+            .padding(
+                horizontal = 20.dp,
+                vertical = 14.dp
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            modifier = Modifier.padding(vertical = 8.dp),
+            text = stringResource(id = R.string.want_this_mission),
+            style = LGTMTheme.typography.body1B,
+            color = LGTMTheme.colors.gray_6
+        )
+        when (likeSuggestionState) {
+            is UiState.Init -> { /* no-op */ }
+            is UiState.Success -> {
                 LikeButton(
-                    likeNum = suggestionDetailState.data.likeNum,
-                    isLiked = suggestionDetailState.data.isLiked
+                    likeNum = likeSuggestionState.data.likeNum,
+                    isLiked = likeSuggestionState.data.isLiked,
+                    onClick = if (likeSuggestionState.data.isLiked) onLikeButtonCancel else onLikeButtonClick
                 )
             }
+            else -> { /* no-op */ }
         }
-        else -> { /* no-op */ }
     }
 }
 

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/SuggestionDetailScreen.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/SuggestionDetailScreen.kt
@@ -41,7 +41,8 @@ import kotlinx.coroutines.launch
 @Composable
 fun SuggestionDetailScreen(
     viewModel: SuggestionDetailViewModel = hiltViewModel(),
-    onBackButtonClick: () -> Unit
+    onBackButtonClick: () -> Unit,
+    onReportSuggestionClick: () -> Unit
 ) {
     val suggestionDetailState by viewModel.detailState.collectAsStateWithLifecycle()
     val likeSuggestionState by viewModel.likeSuggestionState.collectAsStateWithLifecycle()
@@ -72,7 +73,7 @@ fun SuggestionDetailScreen(
                         bottomSheetState.show()
                     }
                 },
-                onReportSuggestion = { /* TODO: 신고 진행 */ },
+                onReportSuggestion = onReportSuggestionClick,
                 onBackButtonClick = onBackButtonClick,
             )
             SuggestionLikeSection(

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/contract/SuggestionDetailInputs.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/contract/SuggestionDetailInputs.kt
@@ -1,0 +1,9 @@
+package com.lgtm.android.mission_suggestion.ui.detail.presentation.contract
+
+interface SuggestionDetailInputs {
+    fun deleteSuggestion()
+    fun reportSuggestion()
+    fun likeSuggestion()
+    fun cancelLikeSuggestion()
+    fun goBack()
+}

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/contract/SuggestionDetailOutputs.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/contract/SuggestionDetailOutputs.kt
@@ -1,0 +1,11 @@
+package com.lgtm.android.mission_suggestion.ui.detail.presentation.contract
+
+import com.lgtm.android.common_ui.model.SuggestionUI
+import com.lgtm.android.common_ui.util.UiState
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+
+interface SuggestionDetailOutputs {
+    val detailState: StateFlow<UiState<SuggestionUI>>
+    val detailUiEffect: SharedFlow<SuggestionDetailUiEffect>
+}

--- a/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/contract/SuggestionDetailUiEffect.kt
+++ b/feature/mission_suggestion/src/main/java/com/lgtm/android/mission_suggestion/ui/detail/presentation/contract/SuggestionDetailUiEffect.kt
@@ -1,0 +1,6 @@
+package com.lgtm.android.mission_suggestion.ui.detail.presentation.contract
+
+sealed class SuggestionDetailUiEffect {
+    data class SendEmail(val msg: String): SuggestionDetailUiEffect()
+    object GoBack: SuggestionDetailUiEffect()
+}


### PR DESCRIPTION
- closed #219 

##### 진행사항
1. `미션 제안 좋아요 / 삭제 / 신고 기능 구현`
 - `input / output / uiEffect` 적용
   - `input`
     - 삭제, 좋아요, 신고 같은 event를 가지고 있는 interface, `viewModel`에서 implement!
   - `output`
     -  state와 uiEffect를 들고 있는 interface, `viewModel`에서 implement!
   - `uiEffect`
     -  백버튼 작동, 이메일 전송처럼 상태 변경이 필요없는 event, `activity`에서 observe!

3. `SuggestionDropDownOneMenu`
 - 메뉴 버튼 눌렀을 때 dropDown 하나 나타나는 거 component로 정의
4. `LgtmConfirmationDialog`
 - ModalBottomSheetLayout를 사용해 dialog component 정의